### PR TITLE
Fix grass loot_tables

### DIFF
--- a/src/main/resources/data/minecraft/loot_tables/blocks/grass.json
+++ b/src/main/resources/data/minecraft/loot_tables/blocks/grass.json
@@ -1,0 +1,75 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:alternatives",
+            "children": [
+              {
+                "type": "minecraft:item",
+                "conditions": [
+                  {
+                    "condition": "minecraft:match_tool",
+                    "predicate": {
+                      "item": "minecraft:shears"
+                    }
+                  }
+                ],
+                "name": "minecraft:grass"
+              },
+              {
+                "type": "minecraft:item",
+                "conditions": [
+                  {
+                    "condition": "minecraft:random_chance",
+                    "chance": 0.125
+                  }
+                ],
+                "functions": [
+                  {
+                    "function": "minecraft:apply_bonus",
+                    "enchantment": "minecraft:fortune",
+                    "formula": "minecraft:uniform_bonus_count",
+                    "parameters": {
+                      "bonusMultiplier": 2
+                    }
+                  },
+                  {
+                    "function": "minecraft:explosion_decay"
+                  }
+                ],
+                "name": "minecraft:wheat_seeds"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:alternatives",
+            "children": [
+              {
+                "type": "minecraft:item",
+                "conditions": [
+                  {
+                    "condition": "minecraft:random_chance",
+                    "chance": 0.125
+                  }
+                ],
+                "functions": [
+                  {
+                    "function": "minecraft:explosion_decay"
+                  }
+                ],
+                "name": "occultism:datura_seeds"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
In 0.2.11，there seems to be something wrong with the loot_table of grass.Things will be like this: I get 64 wheat seed but no demon dream seed, so i have checked the loot table. I found that you have put the grass loot table in data/occultism/loot_tables/blocks , but it doesn't work . So i tried to edit the loot table in data/minecraft/loot_tables/blocks and it do works.Hope you can try it by yourself and if it works . You can do some fix