### PR TITLE
Fix foliot item duplication bug

### DIFF
--- a/src/main/java/com/github/klikli_dev/occultism/common/entity/ai/DepositItemsGoal.java
+++ b/src/main/java/com/github/klikli_dev/occultism/common/entity/ai/DepositItemsGoal.java
@@ -139,10 +139,10 @@ public class DepositItemsGoal extends PausableGoal {
                     ItemStack toInsert = ItemHandlerHelper.insertItem(handler, duplicate, true);
                     //if anything was inserted go for real
                     if (toInsert.getCount() != duplicate.getCount()) {
-                        ItemHandlerHelper.insertItem(handler, duplicate, false);
+                        ItemStack leftover = ItemHandlerHelper.insertItem(handler, duplicate, false);
                         //if we insterted everything
+                        this.entity.setHeldItem(Hand.MAIN_HAND, leftover);
                         if (toInsert.isEmpty()) {
-                            this.entity.setHeldItem(Hand.MAIN_HAND, ItemStack.EMPTY);
                             this.targetBlock = null;
                             this.resetTask();
                         }


### PR DESCRIPTION
This small commit fixes the item duplication bug that can occur when
transport foliots drop off items. It occured when the chest/machine was
so full that the foliot could only drop off part of an item stack. This
commit fixes the bug by always updating the foliot held itemstack no
matter how few items were dropped off.

I believe this also fixes the issue #226 but I have not tested it with Mekanism specifically.