### PR TITLE
Fix greedy familiar curio effect not working after switching dimension

### DIFF
--- a/src/main/java/com/github/klikli_dev/occultism/common/entity/GreedyFamiliarEntity.java
+++ b/src/main/java/com/github/klikli_dev/occultism/common/entity/GreedyFamiliarEntity.java
@@ -171,9 +171,10 @@ public class GreedyFamiliarEntity extends CreatureEntity implements IFamiliar {
 
         wearer.getCapability(OccultismCapabilities.FAMILIAR_SETTINGS).ifPresent(cap -> {
             if(cap.isGreedyEnabled()){
-                for (ItemEntity e : this.world.getEntitiesWithinAABB(ItemEntity.class, wearer.getBoundingBox().grow(5))) {
+                for (ItemEntity e : wearer.world.getEntitiesWithinAABB(ItemEntity.class, wearer.getBoundingBox().grow(5))) {
                     ItemStack stack = e.getItem().getStack();
                     boolean isDemagnetized = stack.hasTag() && stack.getTag().getBoolean("PreventRemoteMovement");
+
                     if(!isDemagnetized){
                         e.onCollideWithPlayer((PlayerEntity) wearer);
                     }

--- a/src/main/java/com/github/klikli_dev/occultism/common/entity/IFamiliar.java
+++ b/src/main/java/com/github/klikli_dev/occultism/common/entity/IFamiliar.java
@@ -73,6 +73,13 @@ public interface IFamiliar {
     /***
      * This method is called every tick when this familiar is captured in a
      * {@link FamiliarRingItem}.
+     * <br><br>
+     * BEWARE: Extra caution has to be taken when using instance variables from the
+     * {@link IFamiliar#getEntity} in this method (such as {@link Entity#world}),
+     * since their values are no longer updated when the familiar is inside the ring
+     * and might be outdated. The same caution should be taken when implementing
+     * {@link IFamiliar#getFamiliarEffects} or any other method that is called while
+     * the familiar is inside the {@link FamiliarRingItem}.
      * 
      * @param wearer The wearer of the curio
      */


### PR DESCRIPTION
This bug occured because the world of the familiar inside the ring was
used to get nearby items, but that world is not updated when changing
dimension. This bug was fixed by switching to use the world of the curio
wearer, which will always be updated. This fixes issue #289.