### PR TITLE
edits dragon familiar entry in dictionary

### DIFF
--- a/src/main/resources/data/occultism/patchouli_books/dictionary_of_spirits/en_us/entries/rituals/familiars/familiar_dragon.json
+++ b/src/main/resources/data/occultism/patchouli_books/dictionary_of_spirits/en_us/entries/rituals/familiars/familiar_dragon.json
@@ -6,16 +6,16 @@
   "pages": [
     {
       "type": "entity",
-      "entity": "occultism:devil_familiar",
-      "text": "$(bold)Provides$(): $(thing)Increased XP$(), Breathes fire"
-    },
-    {
-      "type": "text",
-      "text": "Greedy familiars can ride on dragon familiars, giving the dragon the greedy effects additionally."
+      "entity": "occultism:dragon_familiar",
+      "text": "$(bold)Provides$(): $(thing)Increased XP$(), Loves Sticks"
     },
     {
       "type": "occultism:ritual",
       "recipe": "occultism:ritual/familiar_dragon"
+    },
+    {
+      "type": "text",
+      "text": "Greedy familiars can ride on dragon familiars, giving the dragon the greedy effects additionally."
     }
   ]
 }


### PR DESCRIPTION
fixes #450 
also re-ordered the pages so the recipe is shown before the description as other familiars have.

also, maybe im wrong but i dont see the dragon breathing fire at all so removed that and added his favorite thing!

i was not able to test this as for some reason i could not get it to load as a datapack