### PR TITLE
Switch to minecraft:dirt tag for tree soil

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[38,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[39.0.39,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="MIT"

--- a/src/main/resources/data/occultism/tags/blocks/tree_soil.json
+++ b/src/main/resources/data/occultism/tags/blocks/tree_soil.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "#forge:dirt"
+    "#minecraft:dirt"
   ]
 }


### PR DESCRIPTION
`forge:dirt` blocktag is deprecated as of forge v39.0.39 in favor of the `minecraft:dirt` vanilla tag. As such anyone trying to play with just occultism cannot load the game due to `occultism:tree_soil` referencing a tag that doesn't exist
https://github.com/MinecraftForge/MinecraftForge/pull/7891