### PR TITLE
`raw_ores` -> `raw_materials`

### DIFF
--- a/src/main/resources/data/occultism/recipes/blasting/iesnium_ingot_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/blasting/iesnium_ingot_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:blasting",
   "ingredient": {
-    "tag": "forge:raw_ores/iesnium"
+    "tag": "forge:raw_materials/iesnium"
   },
   "result": "occultism:iesnium_ingot",
   "experience": 0.7,

--- a/src/main/resources/data/occultism/recipes/blasting/silver_ingot_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/blasting/silver_ingot_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:blasting",
   "ingredient": {
-    "tag": "forge:raw_ores/silver"
+    "tag": "forge:raw_materials/silver"
   },
   "result": "occultism:silver_ingot",
   "experience": 0.7,

--- a/src/main/resources/data/occultism/recipes/crushing/copper_dust_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/crushing/copper_dust_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "occultism:crushing",
   "ingredient": {
-    "tag": "forge:raw_ores/copper"
+    "tag": "forge:raw_materials/copper"
   },
   "result": {
     "item": "occultism:copper_dust",

--- a/src/main/resources/data/occultism/recipes/crushing/gold_dust_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/crushing/gold_dust_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "occultism:crushing",
   "ingredient": {
-    "tag": "forge:raw_ores/gold"
+    "tag": "forge:raw_materials/gold"
   },
   "result": {
     "item": "occultism:gold_dust",

--- a/src/main/resources/data/occultism/recipes/crushing/iesnium_dust_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/crushing/iesnium_dust_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "occultism:crushing",
   "ingredient": {
-    "tag": "forge:raw_ores/iesnium"
+    "tag": "forge:raw_materials/iesnium"
   },
   "result": {
     "item": "occultism:iesnium_dust",

--- a/src/main/resources/data/occultism/recipes/crushing/iron_dust_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/crushing/iron_dust_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "occultism:crushing",
   "ingredient": {
-    "tag": "forge:raw_ores/iron"
+    "tag": "forge:raw_materials/iron"
   },
   "result": {
     "item": "occultism:iron_dust",

--- a/src/main/resources/data/occultism/recipes/crushing/silver_dust_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/crushing/silver_dust_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "occultism:crushing",
   "ingredient": {
-    "tag": "forge:raw_ores/silver"
+    "tag": "forge:raw_materials/silver"
   },
   "result": {
     "item": "occultism:silver_dust",

--- a/src/main/resources/data/occultism/recipes/ritual/craft_miner_djinni_ores.json
+++ b/src/main/resources/data/occultism/recipes/ritual/craft_miner_djinni_ores.json
@@ -17,7 +17,7 @@
       "item": "occultism:iesnium_pickaxe"
     },
     {
-      "tag": "forge:raw_ores/gold"
+      "tag": "forge:raw_materials/gold"
     },
     {
       "tag": "forge:storage_blocks/iesnium"

--- a/src/main/resources/data/occultism/recipes/ritual/craft_miner_foliot_unspecialized.json
+++ b/src/main/resources/data/occultism/recipes/ritual/craft_miner_foliot_unspecialized.json
@@ -17,7 +17,7 @@
       "item": "occultism:iesnium_pickaxe"
     },
     {
-      "tag": "forge:raw_ores/iron"
+      "tag": "forge:raw_materials/iron"
     },
     {
       "item": "minecraft:gravel"

--- a/src/main/resources/data/occultism/recipes/ritual/summon_foliot_crusher.json
+++ b/src/main/resources/data/occultism/recipes/ritual/summon_foliot_crusher.json
@@ -14,16 +14,16 @@
   },
   "ingredients": [
     {
-      "tag": "forge:raw_ores/iron"
+      "tag": "forge:raw_materials/iron"
     },
     {
-      "tag": "forge:raw_ores/gold"
+      "tag": "forge:raw_materials/gold"
     },
     {
-      "tag": "forge:raw_ores/copper"
+      "tag": "forge:raw_materials/copper"
     },
     {
-      "tag": "forge:raw_ores/silver"
+      "tag": "forge:raw_materials/silver"
     }
   ],
   "result": {

--- a/src/main/resources/data/occultism/recipes/smelting/iesnium_ingot_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/smelting/iesnium_ingot_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:smelting",
   "ingredient": {
-    "tag": "forge:raw_ores/iesnium"
+    "tag": "forge:raw_materials/iesnium"
   },
   "result": "occultism:iesnium_ingot",
   "experience": 0.7,

--- a/src/main/resources/data/occultism/recipes/smelting/silver_ingot_from_raw.json
+++ b/src/main/resources/data/occultism/recipes/smelting/silver_ingot_from_raw.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:smelting",
   "ingredient": {
-    "tag": "forge:raw_ores/silver"
+    "tag": "forge:raw_materials/silver"
   },
   "result": "occultism:silver_ingot",
   "experience": 0.7,


### PR DESCRIPTION
hai \o

Other mods on 1.18.2 seem to prefer the `raw_materials` tag over `raw_ores`. 
Changing this will help with mod compatibility, and allow the Foliot Crusher to be made in Enigmatica 8 :)

Context: https://github.com/EnigmaticaModpacks/Enigmatica8/issues/187