### PR TITLE
Fix for Demon's Dream Seeds dropping while using Modded Shears

### DIFF
--- a/src/main/resources/data/occultism/loot_modifiers/datura_seed_from_grass.json
+++ b/src/main/resources/data/occultism/loot_modifiers/datura_seed_from_grass.json
@@ -14,9 +14,7 @@
       "term": {
         "condition": "minecraft:match_tool",
         "predicate": {
-          "items": [
-            "minecraft:shears"
-          ]
+          "tag": "forge:shears"
         }
       }
     }

--- a/src/main/resources/data/occultism/loot_modifiers/datura_seed_from_tall_grass.json
+++ b/src/main/resources/data/occultism/loot_modifiers/datura_seed_from_tall_grass.json
@@ -14,9 +14,7 @@
       "term": {
         "condition": "minecraft:match_tool",
         "predicate": {
-          "items": [
-            "minecraft:shears"
-          ]
+          "tag": "forge:shears"
         }
       }
     }


### PR DESCRIPTION
### Beware!
This does also affect 1.18.2 version of the mod (and probably 1.19.1 and 1.19.3, 😅) So not sure if this PR is enough, or I should make few more with those changes on other branches. Just let me know if you want me to do so 😄

### Issue Description
Modded shears with tag "#forge:shears" just doesn't exactly work because of the way loot_modifiers are made, what causes Demon's Dream seeds to drop while using them 😅

### Fix Description
Change out predicate to use Tag instead of Items, so modded Shears can work without issues 😄
I've tested this fix on 1.18.2 and 1.19.2 versions of the mod! Seems to be working fine.