### PR TITLE
Fix items being able to be transferred into the Golden Sacrificial Bowl.

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
@@ -59,11 +59,16 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem;
 import net.minecraftforge.items.IItemHandler;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
@@ -468,6 +473,15 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
                 }
             }
         }
+    }
+
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction direction) {
+        if (cap == ForgeCapabilities.ITEM_HANDLER) {
+            return LazyOptional.empty();
+        }
+        return super.getCapability(cap, direction);
     }
 
     public void onLivingDeath(LivingDeathEvent event) {


### PR DESCRIPTION
Fixes issue #1030.

I looked through the code and found that this was a quick fix, so I did it!

I've tested that this doesn't break the functionality of the Golden Sacrificial Bowl, I can still summon rituals and error detection still works as intended.