### PR TITLE
Modify Beaver summoning ritual

### DIFF
--- a/src/main/resources/data/occultism/recipes/ritual/familiar_beaver.json
+++ b/src/main/resources/data/occultism/recipes/ritual/familiar_beaver.json
@@ -12,16 +12,16 @@
   },
   "ingredients": [
     {
-      "tag": "minecraft:saplings"
+      "tag": "minecraft:logs"
     },
     {
-      "tag": "minecraft:saplings"
+      "tag": "minecraft:logs"
     },
     {
-      "tag": "minecraft:saplings"
+      "tag": "minecraft:logs"
     },
     {
-      "tag": "minecraft:saplings"
+      "tag": "minecraft:logs"
     }
   ],
   "result": {


### PR DESCRIPTION
Changes the Beaver familiar recipe to use logs instead of saplings to avoid a conflict with the Sapling Trader.