### PR TITLE
Backport spirit campfire damage change to 1.19.2 

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismBlocks.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismBlocks.java
@@ -220,7 +220,7 @@ public class OccultismBlocks {
                     .lightLevel((state) -> 10).noOcclusion()));
 
     public static final RegistryObject<Block> SPIRIT_CAMPFIRE = register("spirit_campfire",
-            () -> new CampfireBlock(false, 2, BlockBehaviour.Properties.of(Material.WOOD, MaterialColor.PODZOL)
+            () -> new CampfireBlock(false, 0, BlockBehaviour.Properties.of(Material.WOOD, MaterialColor.PODZOL)
                     .strength(2.0F).sound(SoundType.WOOD).lightLevel((state) -> 10).noOcclusion()));
 
     public static final RegistryObject<Block> SPIRIT_TORCH = register("spirit_torch",


### PR DESCRIPTION
Backports the campfire damage change, as suggested in https://github.com/klikli-dev/occultism/issues/1059 .
I understand if you don't upload this, I just wanted to go ahead and make the change since it was relatively simple.