### PR TITLE
Trial Possession Fix

### DIFF
--- a/src/generated/resources/data/occultism/tags/entity_type/wild_trial.json
+++ b/src/generated/resources/data/occultism/tags/entity_type/wild_trial.json
@@ -1,0 +1,16 @@
+{
+  "values": [
+    "occultism:wild_bogged",
+    "occultism:wild_cave_spider",
+    "occultism:wild_husk",
+    "occultism:wild_silverfish",
+    "occultism:wild_skeleton",
+    "occultism:wild_slime",
+    "occultism:wild_spider",
+    "occultism:wild_stray",
+    "occultism:wild_zombie",
+    "occultism:possessed_strong_breeze",
+    "occultism:possessed_breeze",
+    "occultism:possessed_weak_breeze"
+  ]
+}

--- a/src/main/java/com/klikli_dev/occultism/Occultism.java
+++ b/src/main/java/com/klikli_dev/occultism/Occultism.java
@@ -200,7 +200,7 @@ public class Occultism {
         event.put(OccultismEntities.WILD_SILVERFISH.get(), WildSilverfishEntity.createAttributes().build());
         event.put(OccultismEntities.WILD_SPIDER_TYPE.get(), WildSpiderEntity.createAttributes().build());
         event.put(OccultismEntities.WILD_BOGGED_TYPE.get(), WildBoggedEntity.createAttributes().build());
-        event.put(OccultismEntities.WILD_SLIME_TYPE.get(), WildSlimeEntity.createAttributes().build()); //Wild Slime Attributes error, changed to vanilla slimes
+        event.put(OccultismEntities.WILD_SLIME_TYPE.get(), WildSlimeEntity.createAttributes().build());
         event.put(OccultismEntities.WILD_HUSK_TYPE.get(), WildHuskEntity.createAttributes().build());
         event.put(OccultismEntities.WILD_STRAY_TYPE.get(), WildStrayEntity.createAttributes().build());
         event.put(OccultismEntities.WILD_CAVE_SPIDER_TYPE.get(), WildCaveSpiderEntity.createAttributes().build());

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/PossessedBreezeEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/PossessedBreezeEntity.java
@@ -23,9 +23,13 @@
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
 import com.klikli_dev.occultism.registry.OccultismEntities;
+import com.klikli_dev.occultism.registry.OccultismTags;
 import com.klikli_dev.occultism.util.TextUtil;
 import net.minecraft.network.chat.Component;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.entity.SpawnGroupData;
@@ -69,7 +73,7 @@ public class PossessedBreezeEntity extends Breeze {
         }
 
         for (int i = 0; i < 5; i++) {
-            WildBoggedEntity entity = OccultismEntities.WILD_BOGGED.get().create(this.level());
+            WildStrayEntity entity = OccultismEntities.WILD_STRAY.get().create(this.level());
             EventHooks.finalizeMobSpawn(entity, level, difficultyIn, reason, spawnDataIn);
 
             double offsetX = level.getRandom().nextGaussian() * (1 + level.getRandom().nextInt(4));
@@ -81,9 +85,7 @@ public class PossessedBreezeEntity extends Breeze {
         }
 
         for (int i = 0; i < 5; i++) {
-            //WildSlimeEntity entity = OccultismEntities.WILD_SLIME.get().create(this.level());
-            //Wild Slime Attributes error, changed to vanilla slimes but now gets unintended slimeball
-            Slime entity = EntityType.SLIME.create(this.level());
+            WildCaveSpiderEntity entity = OccultismEntities.WILD_CAVE_SPIDER.get().create(this.level());
             EventHooks.finalizeMobSpawn(entity, level, difficultyIn, reason, spawnDataIn);
 
             double offsetX = level.getRandom().nextGaussian() * (1 + level.getRandom().nextInt(4));
@@ -91,11 +93,25 @@ public class PossessedBreezeEntity extends Breeze {
             entity.absMoveTo(this.getBlockX() + offsetX, this.getBlockY() + 1.5, this.getBlockZ() + offsetZ,
                     level.getRandom().nextInt(360), 0);
             entity.setCustomName(Component.literal(TextUtil.generateName()));
-            entity.setSize(7,true); //Haha bigger slimes
             level.addFreshEntity(entity);
         }
 
         return super.finalizeSpawn(level, difficultyIn, reason, spawnDataIn);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/PossessedStrongBreezeEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/PossessedStrongBreezeEntity.java
@@ -23,9 +23,13 @@
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
 import com.klikli_dev.occultism.registry.OccultismEntities;
+import com.klikli_dev.occultism.registry.OccultismTags;
 import com.klikli_dev.occultism.util.TextUtil;
 import net.minecraft.network.chat.Component;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.entity.SpawnGroupData;
@@ -55,7 +59,7 @@ public class PossessedStrongBreezeEntity extends Breeze {
     public SpawnGroupData finalizeSpawn(ServerLevelAccessor level, DifficultyInstance difficultyIn, MobSpawnType reason,
                                         @Nullable SpawnGroupData spawnDataIn) {
 
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 7; i++) {
             WildHuskEntity entity = OccultismEntities.WILD_HUSK.get().create(this.level());
             EventHooks.finalizeMobSpawn(entity, level, difficultyIn, reason, spawnDataIn);
 
@@ -68,7 +72,7 @@ public class PossessedStrongBreezeEntity extends Breeze {
         }
 
         for (int i = 0; i < 7; i++) {
-            WildStrayEntity entity = OccultismEntities.WILD_STRAY.get().create(this.level());
+            WildBoggedEntity entity = OccultismEntities.WILD_BOGGED.get().create(this.level());
             EventHooks.finalizeMobSpawn(entity, level, difficultyIn, reason, spawnDataIn);
 
             double offsetX = level.getRandom().nextGaussian() * (1 + level.getRandom().nextInt(4));
@@ -80,7 +84,7 @@ public class PossessedStrongBreezeEntity extends Breeze {
         }
 
         for (int i = 0; i < 7; i++) {
-            WildCaveSpiderEntity entity = OccultismEntities.WILD_CAVE_SPIDER.get().create(this.level());
+            WildSlimeEntity entity = OccultismEntities.WILD_SLIME.get().create(this.level());
             EventHooks.finalizeMobSpawn(entity, level, difficultyIn, reason, spawnDataIn);
 
             double offsetX = level.getRandom().nextGaussian() * (1 + level.getRandom().nextInt(4));
@@ -88,10 +92,26 @@ public class PossessedStrongBreezeEntity extends Breeze {
             entity.absMoveTo(this.getBlockX() + offsetX, this.getBlockY() + 1.5, this.getBlockZ() + offsetZ,
                     level.getRandom().nextInt(360), 0);
             entity.setCustomName(Component.literal(TextUtil.generateName()));
+            entity.setSize(8,true); //Haha bigger slimes
             level.addFreshEntity(entity);
         }
 
         return super.finalizeSpawn(level, difficultyIn, reason, spawnDataIn);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/PossessedWeakBreezeEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/PossessedWeakBreezeEntity.java
@@ -24,9 +24,13 @@ package com.klikli_dev.occultism.common.entity.possessed.horde;
 
 import com.klikli_dev.occultism.common.entity.spirit.WildHuntSkeletonEntity;
 import com.klikli_dev.occultism.registry.OccultismEntities;
+import com.klikli_dev.occultism.registry.OccultismTags;
 import com.klikli_dev.occultism.util.TextUtil;
 import net.minecraft.network.chat.Component;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.entity.SpawnGroupData;
@@ -91,6 +95,21 @@ public class PossessedWeakBreezeEntity extends Breeze {
         }
 
         return super.finalizeSpawn(level, difficultyIn, reason, spawnDataIn);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildBoggedEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildBoggedEntity.java
@@ -22,6 +22,10 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -39,16 +43,31 @@ public class WildBoggedEntity extends Bogged {
     //region Static Methods
     public static AttributeSupplier.Builder createAttributes() {
         return Bogged.createAttributes()
-                .add(Attributes.MAX_HEALTH, 45.0)
-                .add(Attributes.ARMOR,10)
-                .add(Attributes.KNOCKBACK_RESISTANCE,0.5);
+                .add(Attributes.MAX_HEALTH, 60.0)
+                .add(Attributes.ARMOR,15)
+                .add(Attributes.KNOCKBACK_RESISTANCE,0.75);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override
     protected boolean shouldDespawnInPeaceful() {
         return false;
     }
-    //endregion Static Methods
+
     @Override
     protected boolean isSunBurnTick() {
         return false;

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildCaveSpiderEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildCaveSpiderEntity.java
@@ -22,6 +22,10 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -38,9 +42,24 @@ public class WildCaveSpiderEntity extends CaveSpider {
     //region Static Methods
     public static AttributeSupplier.Builder createAttributes() {
         return CaveSpider.createAttributes()
-                .add(Attributes.MAX_HEALTH, 60.0)
-                .add(Attributes.ARMOR,15)
-                .add(Attributes.KNOCKBACK_RESISTANCE,0.75);
+                .add(Attributes.MAX_HEALTH, 45.0)
+                .add(Attributes.ARMOR,10)
+                .add(Attributes.KNOCKBACK_RESISTANCE,0.5);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildHordeCreeperEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildHordeCreeperEntity.java
@@ -22,6 +22,8 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import net.minecraft.tags.DamageTypeTags;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -41,6 +43,12 @@ public class WildHordeCreeperEntity extends Creeper {
                 .add(Attributes.ARMOR, 20.0)
                 .add(Attributes.MAX_HEALTH, 5.0)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 1.0);
+    }
+
+    public boolean isInvulnerableTo(DamageSource source) {
+        if (source.is(DamageTypeTags.IS_EXPLOSION))
+            return true;
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildHuskEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildHuskEntity.java
@@ -22,6 +22,10 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -41,6 +45,21 @@ public class WildHuskEntity extends Husk {
                 .add(Attributes.MAX_HEALTH, 60.0)
                 .add(Attributes.ARMOR,15)
                 .add(Attributes.KNOCKBACK_RESISTANCE,0.75);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildSilverfishEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildSilverfishEntity.java
@@ -22,6 +22,10 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -41,6 +45,21 @@ public class WildSilverfishEntity extends Silverfish {
                 .add(Attributes.MAX_HEALTH, 30.0)
                 .add(Attributes.ARMOR,5)
                 .add(Attributes.KNOCKBACK_RESISTANCE,0.25);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildSkeletonEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildSkeletonEntity.java
@@ -22,6 +22,10 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -41,6 +45,21 @@ public class WildSkeletonEntity extends Skeleton {
                 .add(Attributes.MAX_HEALTH, 30.0)
                 .add(Attributes.ARMOR,5)
                 .add(Attributes.KNOCKBACK_RESISTANCE,0.25);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildSlimeEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildSlimeEntity.java
@@ -22,32 +22,55 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
-import net.minecraft.world.entity.EntityType;
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.entity.monster.Slime;
 import net.minecraft.world.level.Level;
 
 public class WildSlimeEntity extends Slime {
 
-    public WildSlimeEntity(EntityType<? extends Slime> type,
-                           Level worldIn) {
-        super(type, worldIn);
+    public WildSlimeEntity(EntityType<? extends WildSlimeEntity> type, Level world) {
+        super(type, world);
     }
 
-    //region Static Methods
+    @Override
+    public void setSize(int size, boolean resetHealth) {
+        super.setSize(size, resetHealth);
+        this.xpReward = size - 1;
+    }
 
-    //Wild Slime Attributes error, changed to vanilla slimes
     public static AttributeSupplier.Builder createAttributes() {
-        return Slime.createMobAttributes()
-                .add(Attributes.MAX_HEALTH, 45.0)
-                .add(Attributes.ARMOR,10)
-                .add(Attributes.KNOCKBACK_RESISTANCE,0.5);
+        return Monster.createMonsterAttributes()
+                .add(Attributes.MAX_HEALTH);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
+    }
+
+    @Override
+    protected float getSoundVolume() {
+        return 0.1F * this.getSize();
     }
 
     @Override
     protected boolean shouldDespawnInPeaceful() {
         return false;
     }
-    //endregion Static Methods
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildSpiderEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildSpiderEntity.java
@@ -22,6 +22,10 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -41,6 +45,21 @@ public class WildSpiderEntity extends Spider {
                 .add(Attributes.MAX_HEALTH, 45.0)
                 .add(Attributes.ARMOR,10)
                 .add(Attributes.KNOCKBACK_RESISTANCE,0.5);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildStrayEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildStrayEntity.java
@@ -22,6 +22,10 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -38,9 +42,24 @@ public class WildStrayEntity extends Stray {
     //region Static Methods
     public static AttributeSupplier.Builder createAttributes() {
         return Stray.createAttributes()
-                .add(Attributes.MAX_HEALTH, 60.0)
-                .add(Attributes.ARMOR,15)
-                .add(Attributes.KNOCKBACK_RESISTANCE,0.75);
+                .add(Attributes.MAX_HEALTH, 45.0)
+                .add(Attributes.ARMOR,10)
+                .add(Attributes.KNOCKBACK_RESISTANCE,0.5);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildZombieEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/possessed/horde/WildZombieEntity.java
@@ -22,6 +22,10 @@
 
 package com.klikli_dev.occultism.common.entity.possessed.horde;
 
+import com.klikli_dev.occultism.registry.OccultismTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -41,6 +45,21 @@ public class WildZombieEntity extends Zombie {
                 .add(Attributes.MAX_HEALTH, 30.0)
                 .add(Attributes.ARMOR,5)
                 .add(Attributes.KNOCKBACK_RESISTANCE,0.25);
+    }
+
+    @Override
+    public boolean isInvulnerableTo(DamageSource source) {
+        TagKey<EntityType<?>> wildTrialTag = OccultismTags.Entities.WILD_TRIAL;
+
+        Entity trueSource = source.getEntity();
+        if (trueSource != null && trueSource.getType().is(wildTrialTag))
+            return true;
+
+        Entity immediateSource = source.getDirectEntity();
+        if (immediateSource != null && immediateSource.getType().is(wildTrialTag))
+            return true;
+
+        return super.isInvulnerableTo(source);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/datagen/tags/OccultismEntityTypeTagProvider.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/tags/OccultismEntityTypeTagProvider.java
@@ -106,6 +106,20 @@ public class OccultismEntityTypeTagProvider extends EntityTypeTagsProvider {
                 .add(OccultismEntities.WILD_HUNT_SKELETON_TYPE.get())
                 .add(OccultismEntities.WILD_HUNT_WITHER_SKELETON_TYPE.get())
                 .replace(false);
+        this.tag(OccultismTags.Entities.WILD_TRIAL)
+                .add(OccultismEntities.WILD_BOGGED_TYPE.get())
+                .add(OccultismEntities.WILD_CAVE_SPIDER_TYPE.get())
+                .add(OccultismEntities.WILD_HUSK_TYPE.get())
+                .add(OccultismEntities.WILD_SILVERFISH_TYPE.get())
+                .add(OccultismEntities.WILD_SKELETON_TYPE.get())
+                .add(OccultismEntities.WILD_SLIME_TYPE.get())
+                .add(OccultismEntities.WILD_SPIDER_TYPE.get())
+                .add(OccultismEntities.WILD_STRAY_TYPE.get())
+                .add(OccultismEntities.WILD_ZOMBIE_TYPE.get())
+                .add(OccultismEntities.POSSESSED_STRONG_BREEZE_TYPE.get())
+                .add(OccultismEntities.POSSESSED_BREEZE_TYPE.get())
+                .add(OccultismEntities.POSSESSED_WEAK_BREEZE_TYPE.get())
+                .replace(false);
 
 
         this.tag(OccultismTags.Entities.RANDOM_ANIMALS_TO_SUMMON_LIST)

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismTags.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismTags.java
@@ -145,6 +145,7 @@ public class OccultismTags {
         public static final TagKey<EntityType<?>> SOUL_GEM_DENY_LIST = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "soul_gem_deny_list"));
         public static final TagKey<EntityType<?>> AFRIT_ALLIES = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "afrit_allies"));
         public static final TagKey<EntityType<?>> WILD_HUNT = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "wild_hunt"));
+        public static final TagKey<EntityType<?>> WILD_TRIAL = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "wild_trial"));
         public static final TagKey<EntityType<?>> HEALED_BY_DEMONS_DREAM_FRUIT = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "healed_by_demons_dream_fruit"));
         public static final TagKey<EntityType<?>> CUBEMOB = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "cubemob"));
         public static final TagKey<EntityType<?>> FLYING_PASSIVE = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "flying_passive"));


### PR DESCRIPTION
Adjustments to the mobs sequence in trial horde (breeze possessions);
Wild Slimes now work;
Trial horde mobs are invulnerable to each other;
Horde Creeper invulnerable to explosions;

