### PR TITLE
fix: update weather ritual to match natural rain clearing behavior

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/ClearWeatherJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/ClearWeatherJob.java
@@ -37,7 +37,7 @@ public class ClearWeatherJob extends ChangeWeatherJob {
         if (Occultism.SERVER_CONFIG.rituals.enableClearWeatherRitual.get()) {
             //taken from weathercommand#clear
             ServerLevelData level = (ServerLevelData) this.entity.level().getLevelData();
-            level.setClearWeatherTime(6000);
+            level.setClearWeatherTime(0);
             level.setRainTime(0);
             level.setThunderTime(0);
             level.setRaining(false);


### PR DESCRIPTION
If you set the clear weather time to 6000, then after 6000 ticks it will always rain. Setting it to 0 instead clears the weather will have resume its natural cycle.