### PR TITLE
Three fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,13 @@ repositories {
             includeGroup "dev.emi"
         }
     }
+    maven {
+        name = "Shadows of Fire"
+        url "https://maven.shadowsoffire.dev/releases"
+        content {
+            includeGroup "dev.shadowsoffire"
+        }
+    }
     flatDir {
         dirs 'lib'
     }
@@ -188,6 +195,11 @@ dependencies {
     //runtimeOnly "curse.maven:perviaminvenire-449945:xyz" //
     //enable once available for 1.20
     //runtimeOnly "com.ldtteam:per_viam_invenire:1.19.3-XYZ-RELEASE:universal"
+
+    //Apothic Enchanting
+    compileOnly ("dev.shadowsoffire:ApothicEnchanting:${minecraft_version}-${apothic_enchanting_version}") {transitive=false}
+    //need more dependencies, so it doesn't run here
+    //runtimeOnly ("dev.shadowsoffire:ApothicEnchanting:${minecraft_version}-${apothic_enchanting_version}") {transitive=false}
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,3 +55,5 @@ theurgy_version_range=[1.47.1,)
 per_viam_invenire_version_range=[0.1.57,)
 emi_version=1.1.14+1.21.1
 emi_version_range=[1.1.7+1.21,)
+apothic_enchanting_version=1.2.5
+apothic_enchanting_version_range=[1.2.5,)

--- a/src/generated/resources/assets/occultism/lang/en_us.json
+++ b/src/generated/resources/assets/occultism/lang/en_us.json
@@ -262,8 +262,6 @@
   "book.occultism.dictionary_of_spirits.crafting_rituals.craft_foliot_miner.magic_lamp.title": "Magic Lamp",
   "book.occultism.dictionary_of_spirits.crafting_rituals.craft_foliot_miner.name": "Foliot Miner",
   "book.occultism.dictionary_of_spirits.crafting_rituals.craft_foliot_miner.spotlight.text": "The [#](ad03fc)Foliot[#]() miner harvests block without much aim and returns anything it finds. The mining process is quite slow, due to this the Foliot expends only minor amounts of energy, damaging the lamp it is housed in slowly over time.\n",
-  "book.occultism.dictionary_of_spirits.crafting_rituals.craft_iesnium_anvil.apothic.text": "When using [#](AA00AA)Apothic Enchanting Mod[#]() you can get all enchantments at level 10 instead of one level higher than the maximum\n",
-  "book.occultism.dictionary_of_spirits.crafting_rituals.craft_iesnium_anvil.apothic.title": "Apotheosis Information",
   "book.occultism.dictionary_of_spirits.crafting_rituals.craft_iesnium_anvil.description": "Upgraded Anvil",
   "book.occultism.dictionary_of_spirits.crafting_rituals.craft_iesnium_anvil.name": "Iesnium Anvil",
   "book.occultism.dictionary_of_spirits.crafting_rituals.craft_iesnium_anvil.spotlight.text": "The [](item://occultism:iesnium_anvil) is a [#](AA00AA)Marid[#]() infusion.\nThis anvil has some improvements:\n1. Is unbreakable;\n2. Can exceed the maximum level of enchantments by 1;\n3. Marid will pay half of the showed level cost (round up);\n4. The cost increase of working with the same item is reduced;\n5. The maximum cost limit is increased;\n",

--- a/src/generated/resources/data/c/tags/item/dusts/sky_stone.json
+++ b/src/generated/resources/data/c/tags/item/dusts/sky_stone.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "ae2:sky_dust",
+      "required": false
+    }
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/sky_stones.json
+++ b/src/generated/resources/data/c/tags/item/sky_stones.json
@@ -1,0 +1,20 @@
+{
+  "values": [
+    {
+      "id": "ae2:sky_stone_block",
+      "required": false
+    },
+    {
+      "id": "ae2:smooth_sky_stone_block",
+      "required": false
+    },
+    {
+      "id": "ae2:sky_stone_brick",
+      "required": false
+    },
+    {
+      "id": "ae2:sky_stone_small_brick",
+      "required": false
+    }
+  ]
+}

--- a/src/generated/resources/data/occultism/advancement/recipes/crushing/crushing/ender_pearl_dust_from_tag.json
+++ b/src/generated/resources/data/occultism/advancement/recipes/crushing/crushing/ender_pearl_dust_from_tag.json
@@ -1,0 +1,48 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:ender_pearls"
+      }
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:dusts/ender_pearl"
+      }
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_ender_pearl": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#c:ender_pearls"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "occultism:crushing/ender_pearl_dust_from_tag"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_ender_pearl"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "occultism:crushing/ender_pearl_dust_from_tag"
+    ]
+  }
+}

--- a/src/generated/resources/data/occultism/advancement/recipes/crushing/crushing/sky_stone_dust.json
+++ b/src/generated/resources/data/occultism/advancement/recipes/crushing/crushing/sky_stone_dust.json
@@ -1,0 +1,48 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:sky_stones"
+      }
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:dusts/sky_stone"
+      }
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_sky_stone": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#c:sky_stones"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "occultism:crushing/sky_stone_dust"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_sky_stone"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "occultism:crushing/sky_stone_dust"
+    ]
+  }
+}

--- a/src/generated/resources/data/occultism/recipe/crushing/ender_pearl_dust_from_tag.json
+++ b/src/generated/resources/data/occultism/recipe/crushing/ender_pearl_dust_from_tag.json
@@ -1,0 +1,27 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:ender_pearls"
+      }
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:dusts/ender_pearl"
+      }
+    }
+  ],
+  "type": "occultism:crushing",
+  "ingredient": {
+    "tag": "c:ender_pearls"
+  },
+  "result": {
+    "type": "occultism:tag",
+    "count": 2,
+    "tag": "c:dusts/ender_pearl"
+  }
+}

--- a/src/generated/resources/data/occultism/recipe/crushing/sky_stone_dust.json
+++ b/src/generated/resources/data/occultism/recipe/crushing/sky_stone_dust.json
@@ -1,0 +1,28 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:sky_stones"
+      }
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:tag_empty",
+        "tag": "c:dusts/sky_stone"
+      }
+    }
+  ],
+  "type": "occultism:crushing",
+  "ignore_crushing_multiplier": true,
+  "ingredient": {
+    "tag": "c:sky_stones"
+  },
+  "result": {
+    "type": "occultism:tag",
+    "count": 1,
+    "tag": "c:dusts/sky_stone"
+  }
+}

--- a/src/generated/resources/data/occultism/tags/entity_type/soul_gem_deny_list.json
+++ b/src/generated/resources/data/occultism/tags/entity_type/soul_gem_deny_list.json
@@ -4,7 +4,6 @@
       "id": "#c:capturing_not_supported",
       "required": false
     },
-    "minecraft:wither",
-    "minecraft:ender_dragon"
+    "#c:bosses"
   ]
 }

--- a/src/main/java/com/klikli_dev/occultism/client/gui/IesniumAnvilMenu.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/IesniumAnvilMenu.java
@@ -1,5 +1,6 @@
 package com.klikli_dev.occultism.client.gui;
 
+import com.klikli_dev.occultism.integration.apothicenchanting.ApothicEnchantingIntegration;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
@@ -14,7 +15,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
-import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.AnvilUpdateEvent;
 import org.jetbrains.annotations.NotNull;
@@ -145,9 +145,9 @@ public class IesniumAnvilMenu extends AnvilMenu {
                             flag3 = true;
                         } else {
                             flag2 = true;
-                            if(ModList.get().isLoaded("apothic_enchanting")) {
-                                if (j2 > 9) {
-                                    j2 = 10;
+                            if(ApothicEnchantingIntegration.isLoaded()) {
+                                if (j2 > ApothicEnchantingIntegration.getApothicMaxLevel(enchantment)) {
+                                    j2 = ApothicEnchantingIntegration.getApothicMaxLevel(enchantment) + 1;
                                 }
                             } else {
                                 if (j2 > enchantment.getMaxLevel()) {

--- a/src/main/java/com/klikli_dev/occultism/datagen/book/binding_rituals/IesniumAnvilEntry.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/book/binding_rituals/IesniumAnvilEntry.java
@@ -5,7 +5,6 @@ import com.klikli_dev.modonomicon.api.datagen.EntryBackground;
 import com.klikli_dev.modonomicon.api.datagen.EntryProvider;
 import com.klikli_dev.modonomicon.api.datagen.book.BookIconModel;
 import com.klikli_dev.modonomicon.api.datagen.book.page.BookSpotlightPageModel;
-import com.klikli_dev.modonomicon.api.datagen.book.page.BookTextPageModel;
 import com.klikli_dev.occultism.integration.modonomicon.pages.BookRitualRecipePageModel;
 import com.klikli_dev.occultism.registry.OccultismBlocks;
 import com.mojang.datafixers.util.Pair;
@@ -42,16 +41,6 @@ public class IesniumAnvilEntry extends EntryProvider {
                 .withRecipeId1(this.modLoc("ritual/craft_iesnium_anvil"))
         );
         //no text
-
-        this.page("apothic", () -> BookTextPageModel.create()
-                .withTitle(this.context().pageTitle())
-                .withText(this.context().pageText()));
-        this.pageTitle("Apotheosis Information");
-        this.pageText("""
-                        When using {0} you can get all enchantments at level 10 instead of one level higher than the maximum
-                        """,
-                this.color("Apothic Enchanting Mod", ChatFormatting.DARK_PURPLE)
-        );
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/datagen/recipe/OccultismRecipeProvider.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/recipe/OccultismRecipeProvider.java
@@ -407,7 +407,11 @@ public class OccultismRecipeProvider extends RecipeProvider {
                 .setIgnoreCrushingMultiplier(true)
                 .unlockedBy("has_coal", has(ItemTags.COALS))
                 .save(pRecipeOutput, ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "crushing/coal_dust_from_tag"));
-
+        CrushingRecipeBuilder.crushingRecipe(Tags.Items.ENDER_PEARLS, OccultismTags.makeItemTag(ResourceLocation.fromNamespaceAndPath("c", "dusts/" + "ender_pearl")), 200)
+                .setAllowEmpty(false)
+                .setResultAmount(2)
+                .unlockedBy("has_ender_pearl", has(Tags.Items.ENDER_PEARLS))
+                .save(pRecipeOutput, ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "crushing/ender_pearl_dust_from_tag"));
         CrushingRecipeBuilder.crushingRecipe(Tags.Items.RODS_BLAZE, Items.BLAZE_POWDER, 200)
                 .allowEmpty()
                 .setResultAmount(4)
@@ -480,7 +484,12 @@ public class OccultismRecipeProvider extends RecipeProvider {
                 .setIgnoreCrushingMultiplier(true)
                 .setMinTier(4)
                 .save(pRecipeOutput, ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "crushing/echo_dust"));
-
+        CrushingRecipeBuilder.crushingRecipe(OccultismTags.makeItemTag(ResourceLocation.fromNamespaceAndPath("c", "sky_stones")), OccultismTags.makeItemTag(ResourceLocation.fromNamespaceAndPath("c", "dusts/sky_stone")), 200)
+                .unlockedBy("has_sky_stone", has(OccultismTags.makeItemTag(ResourceLocation.fromNamespaceAndPath("c", "sky_stones"))))
+                .setResultAmount(1)
+                .setAllowEmpty(false)
+                .setIgnoreCrushingMultiplier(true)
+                .save(pRecipeOutput, ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "crushing/sky_stone_dust"));
     }
 
     private void crushingGemRecipe(String gemName, RecipeOutput recipeOutput) {

--- a/src/main/java/com/klikli_dev/occultism/datagen/tags/OccultismEntityTypeTagProvider.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/tags/OccultismEntityTypeTagProvider.java
@@ -125,9 +125,6 @@ public class OccultismEntityTypeTagProvider extends EntityTypeTagsProvider {
                 .add(EntityType.PLAYER)
                 .replace(false);
 
-        this.tag(OccultismTags.Entities.SOUL_GEM_DENY_LIST)
-                .add(EntityType.WITHER, EntityType.ENDER_DRAGON)
-                .replace(false);
         this.tag(OccultismTags.Entities.WILD_HUNT)
                 .add(OccultismEntities.WILD_HUNT_SKELETON_TYPE.get())
                 .add(OccultismEntities.WILD_HUNT_WITHER_SKELETON_TYPE.get())
@@ -202,7 +199,7 @@ public class OccultismEntityTypeTagProvider extends EntityTypeTagsProvider {
     }
 
     private void addCommonTags() {
-        this.tag(OccultismTags.Entities.SOUL_GEM_DENY_LIST).addOptionalTag(Tags.EntityTypes.CAPTURING_NOT_SUPPORTED);
+        this.tag(OccultismTags.Entities.SOUL_GEM_DENY_LIST).addOptionalTag(Tags.EntityTypes.CAPTURING_NOT_SUPPORTED).addTag(Tags.EntityTypes.BOSSES);
 
         this.tag(OccultismTags.Entities.SNOW_GOLEM).add(EntityType.SNOW_GOLEM).replace(false);
         this.tag(OccultismTags.Entities.IRON_GOLEM).add(EntityType.IRON_GOLEM).replace(false);

--- a/src/main/java/com/klikli_dev/occultism/datagen/tags/OccultismItemTagProvider.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/tags/OccultismItemTagProvider.java
@@ -67,14 +67,17 @@ public class OccultismItemTagProvider extends ItemTagsProvider {
         this.tag(this.cTag("ores/dark_gem"))
                 .addOptional(this.loc("evilcraft:dark_ores"))
                 .addOptionalTag(this.loc("evilcraft:ores/dark_gem")); //does not exist as of 1.21, but if they unify the pattern it will
-
-        this.tag(this.cTag("dusts/dark_gem"))
-                .addOptional(this.loc("evilcraft:dark_gem_crushed"));
+        this.tag(this.cTag("dusts/dark_gem")).addOptional(this.loc("evilcraft:dark_gem_crushed"));
         this.tag(this.cTag("ores/black_quartz")).addOptional(this.loc("actuallyadditions:black_quartz_ore"));
         this.tag(this.cTag("gems/black_quartz")).addOptional(this.loc("actuallyadditions:black_quartz"));
         this.tag(this.cTag("dusts/certus_quartz")).addOptional(this.loc("ae2:certus_quartz_dust"));
         this.tag(this.cTag("dusts/fluix")).addOptional(this.loc("ae2:fluix_dust"));
-        this.tag(this.cTag("gems/fluix")).addOptional(this.loc("ae2:fluix_crystal"));
+        this.tag(this.cTag("dusts/sky_stone")).addOptional(this.loc("ae2:sky_dust"));
+        this.tag(this.cTag("sky_stones"))
+                .addOptional(this.loc("ae2:sky_stone_block"))
+                .addOptional(this.loc("ae2:smooth_sky_stone_block"))
+                .addOptional(this.loc("ae2:sky_stone_brick"))
+                .addOptional(this.loc("ae2:sky_stone_small_brick"));
     }
 
     private void addCuriosTags(HolderLookup.Provider provider) {

--- a/src/main/java/com/klikli_dev/occultism/integration/apothicenchanting/ApothicEnchantingIntegration.java
+++ b/src/main/java/com/klikli_dev/occultism/integration/apothicenchanting/ApothicEnchantingIntegration.java
@@ -1,0 +1,27 @@
+package com.klikli_dev.occultism.integration.apothicenchanting;
+
+import dev.shadowsoffire.apothic_enchanting.ApothicEnchanting;
+import dev.shadowsoffire.apothic_enchanting.util.MiscUtil;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.neoforged.fml.ModList;
+
+public class ApothicEnchantingIntegration {
+    public static boolean isLoaded() {
+        return ModList.get().isLoaded("apothic_enchanting");
+    }
+
+    /**
+     * Copied from Apothic Enchanting Hooks
+     * Using a different function to call in iesnium anvil
+     */
+    public static int getApothicMaxLevel(Enchantment enchantment){
+        Holder<Enchantment> holder = MiscUtil.findHolder(Registries.ENCHANTMENT, enchantment);
+        if (holder != null) {
+            return ApothicEnchanting.getEnchInfo(holder).getMaxLevel();
+        }
+        return enchantment.getMaxLevel();
+    }
+
+}

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismItems.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismItems.java
@@ -380,7 +380,8 @@ public class OccultismItems {
     public static final DeferredItem<DimensionalMatrixItem> DIMENSIONAL_MATRIX = ITEMS.register("dimensional_matrix",
             () -> new DimensionalMatrixItem(defaultProperties().component(OccultismDataComponents.SPIRIT_NAME, "(Not yet known)")));
     public static final DeferredItem<Item> MINING_DIMENSION_CORE_PIECE = ITEMS.register("mining_dim_core",
-            () -> new Item(defaultProperties()));
+            () -> new Item(defaultProperties()
+                    .component(OccultismDataComponents.SPIRIT_NAME, "Something")));
 
     //Others
     public static final DeferredItem<SoulShardItem> SOUL_SHARD_ITEM = ITEMS.register("soul_shard",


### PR DESCRIPTION
Solve #1276 adding a fixed name in mining dimension core

Solve #1278 adding a real integration with apothic enchanting

The soul gem blacklist uses "c:bosses" instead of "minecraft:wither" and "minecraft:ender_dragon", because this tag contains those entities and modded bosses (The Boo made me check this because of a message on discord) 

Bonus: crushing ender pearl and sky stone (ae2)