### PR TITLE
Spirit inventory updates

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/container/spirit/SpiritContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/spirit/SpiritContainer.java
@@ -56,16 +56,19 @@ public class SpiritContainer extends AbstractContainerMenu {
     public ItemStack quickMoveStack(Player playerIn, int index) {
         ItemStack itemstack = ItemStack.EMPTY;
         Slot slot = this.slots.get(index);
+
         if (slot != null && slot.hasItem()) {
             ItemStack itemstack1 = slot.getItem();
             itemstack = itemstack1.copy();
-            if (index < this.inventory.getSlots()) {
-                if (!this.moveItemStackTo(itemstack1, this.inventory.getSlots(), this.slots.size(), true)) {
+            
+            if (index >= this.slots.size() - this.inventory.getSlots()) {
+                if (!this.moveItemStackTo(itemstack1, 0, this.slots.size() - this.inventory.getSlots(), true)) {
                     return ItemStack.EMPTY;
                 }
-            } else if (!this.moveItemStackTo(itemstack1, 0, this.inventory.getSlots(), false)) {
+            } else if (!this.moveItemStackTo(itemstack1, this.slots.size() - this.inventory.getSlots(), this.slots.size(), true)) {
                 return ItemStack.EMPTY;
             }
+            
 
             if (itemstack1.isEmpty()) {
                 slot.set(ItemStack.EMPTY);

--- a/src/main/java/com/klikli_dev/occultism/common/container/spirit/SpiritTransporterContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/spirit/SpiritTransporterContainer.java
@@ -110,6 +110,35 @@ public class SpiritTransporterContainer extends SpiritContainer {
         }
     }
 
+    @Override
+    public ItemStack quickMoveStack(Player playerIn, int index) {
+        ItemStack itemstack = ItemStack.EMPTY;
+        Slot slot = this.slots.get(index);
+        final int filterSize = 14; // CHANGE IF FILTER SIZE IS CHANGED
+
+        if (slot != null && slot.hasItem()) {
+            ItemStack itemstack1 = slot.getItem();
+            itemstack = itemstack1.copy();
+            
+            if (index >= this.slots.size() - this.inventory.getSlots() - filterSize) {
+                if (!this.moveItemStackTo(itemstack1, 0, this.slots.size() - this.inventory.getSlots() - filterSize, true)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (!this.moveItemStackTo(itemstack1, this.slots.size() - this.inventory.getSlots() - filterSize, this.slots.size() - filterSize, true)) {
+                return ItemStack.EMPTY;
+            }
+            
+
+            if (itemstack1.isEmpty()) {
+                slot.set(ItemStack.EMPTY);
+            } else {
+                slot.setChanged();
+            }
+        }
+
+        return itemstack;
+    }
+
     public class FilterSlot extends SlotItemHandler {
 
         public FilterSlot(IItemHandler handler, int inventoryIndex, int x, int y) {

--- a/src/main/java/com/klikli_dev/occultism/common/entity/spirit/SpiritEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/spirit/SpiritEntity.java
@@ -679,14 +679,11 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
 
     @Override
     public InteractionResult interactAt(Player player, Vec3 vec, InteractionHand hand) {
-        ItemStack itemStack = player.getItemInHand(hand);
-
-        if (itemStack.isEmpty()) {
-            if (this.isTame() && player.isShiftKeyDown()) {
-                this.openScreen(player);
-                return InteractionResult.SUCCESS;
-            }
+        if (this.isTame() && player.isShiftKeyDown()) {
+            this.openScreen(player);
+            return InteractionResult.SUCCESS;
         }
+        
         return super.interactAt(player, vec, hand);
     }
 


### PR DESCRIPTION
Ensured quickmove into spirit inventories work from hotbar and work with filters (janitor and transporter)
Changed spirit inventory access to work even with an item in hand
Issue #1155, items 4 and 5 (DON'T CLOSE ISSUE)