### PR TITLE
feat: add Jade/Waila plugin that hides IOtherworldBlocks if covered, fixes #1310

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     //alltheores - for recipe testing
     //enable once available for 1.20
     //runtimeOnly "curse.maven:alltheores-405593:xyz" //
-
+    implementation "curse.maven:jade-324717:${jade_id}"
     //PerViamInvenire - for AI integration testing
     //runtimeOnly "curse.maven:perviaminvenire-449945:xyz" //
     //enable once available for 1.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,3 +57,4 @@ emi_version=1.1.14+1.21.1
 emi_version_range=[1.1.7+1.21,)
 apothic_enchanting_version=1.2.5
 apothic_enchanting_version_range=[1.2.5,)
+jade_id=6155158

--- a/src/main/java/com/klikli_dev/occultism/integration/waila/OccultismPlugin.java
+++ b/src/main/java/com/klikli_dev/occultism/integration/waila/OccultismPlugin.java
@@ -1,0 +1,41 @@
+package com.klikli_dev.occultism.integration.waila;
+
+import com.klikli_dev.occultism.Occultism;
+import com.klikli_dev.occultism.api.common.data.OtherworldBlockTier;
+import com.klikli_dev.occultism.common.block.otherworld.IOtherworldBlock;
+import com.klikli_dev.occultism.registry.OccultismBlocks;
+import com.klikli_dev.occultism.util.CuriosUtil;
+import net.minecraft.world.level.block.Blocks;
+import snownee.jade.api.*;
+
+@WailaPlugin
+public class OccultismPlugin implements IWailaPlugin {
+    @Override
+    public void register(IWailaCommonRegistration registration) {
+        //TODO register data providers
+    }
+
+    @Override
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.addRayTraceCallback((hitResult, accessor, originalAccessor) -> {
+            if(accessor!=null) {
+                boolean hasGoggles = CuriosUtil.hasGoggles(accessor.getPlayer());
+                if (accessor instanceof BlockAccessor blockAccessor) {
+                    if (blockAccessor.getBlock() instanceof IOtherworldBlock otherworldBlock) {
+                        if (otherworldBlock.getTier() == OtherworldBlockTier.ONE || hasGoggles) {
+                            if (blockAccessor.getBlockState().getValue(IOtherworldBlock.UNCOVERED)) {
+                                return registration.blockAccessor().from(blockAccessor).blockState(otherworldBlock.getUncoveredBlock().defaultBlockState()).build();
+                            } else {
+                                return registration.blockAccessor().from(blockAccessor).blockState(otherworldBlock.getCoveredBlock().defaultBlockState()).build();
+                            }
+                        } else {
+                            return registration.blockAccessor().from(blockAccessor).blockState(otherworldBlock.getCoveredBlock().defaultBlockState()).build();
+                        }
+                    }
+                }
+            }
+            return accessor;
+        });
+    }
+
+}


### PR DESCRIPTION
This addition of a plugin will hide IOtherworldBlocks on Waila/Jade

![image](https://github.com/user-attachments/assets/adf955ae-8088-4ee3-9fb0-4cc115127fbf)
When looking at an otherworld sapling, but when looking at it under third eye effect, you get this instead
![image](https://github.com/user-attachments/assets/bf05316c-6f03-4860-abe4-c7e7fcaae71e)
