### PR TITLE
Backported the EMI ritual recipe fix to the 1.20.1 branch

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/integration/emi/recipes/RitualRecipeCategory.java
+++ b/src/main/java/com/klikli_dev/occultism/integration/emi/recipes/RitualRecipeCategory.java
@@ -66,6 +66,7 @@ public class RitualRecipeCategory implements EmiRecipe {
                 }
             }
         }
+        outputs.add(EmiStack.of(recipe.getRitualDummy()));
         return outputs;
     }
 


### PR DESCRIPTION
Merged the fix from the 1.21.1 branch and tested that it works in the older version.