### PR TITLE
Update GoldenSacrificialBowlBlockEntity.java

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
@@ -92,6 +92,7 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
 
     public Consumer<RightClickItem> rightClickItemListener;
     public Consumer<LivingDeathEvent> livingDeathEventListener;
+    private boolean pendingSync;
 
 
     public GoldenSacrificialBowlBlockEntity(BlockPos worldPos, BlockState state) {
@@ -475,6 +476,9 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
 
             if (recipe.value().getDuration() >= 0 && this.currentTime >= recipe.value().getDuration())
                 this.stopRitual(true);
+        } else if (this.pendingSync) {
+            this.markNetworkDirty();
+            this.pendingSync = false;
         }
     }
 
@@ -705,13 +709,13 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
     public void notifySacrifice(LivingEntity entityLivingBase) {
         this.sacrificeProvided = true;
         this.setChanged();
-        this.markNetworkDirty();
+        this.pendingSync = true;
     }
 
     public void notifyItemUse(PlayerInteractEvent.RightClickItem event) {
         this.itemUseProvided = true;
         this.setChanged();
-        this.markNetworkDirty();
+        this.pendingSync = true;
     }
 
     public void onPlayerRightClickItem(PlayerInteractEvent.RightClickItem event) {


### PR DESCRIPTION
Fix #1448 
+ markNetworkDirty only in client, as it should be
+ Sodium compatibility