### PR TITLE
fix: prevent Fracture Soul enchantment from affecting players

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/handlers/LootEventHandler.java
+++ b/src/main/java/com/klikli_dev/occultism/handlers/LootEventHandler.java
@@ -147,7 +147,7 @@ public class LootEventHandler {
 
         if (killer instanceof LivingEntity living) {
             int level = living.getWeaponItem().getEnchantmentLevel(killed.level().holderOrThrow(OccultismEnchantments.FRACTURE_SOUL));
-            if (level == 0 || killed.getType().is(OccultismTags.Entities.SOUL_SHATTERED_DENY_LIST) || killed instanceof IFamiliar) {
+            if (level == 0 || killed.getType().is(OccultismTags.Entities.SOUL_SHATTERED_DENY_LIST) || killed instanceof IFamiliar || killed instanceof Player) {
                 return;
             }
 


### PR DESCRIPTION
Adds a check to ensure the Fracture Soul logic does not execute when the killed entity is a Player. This prevents unintended soul shard creation behavior during PvP.

Fixes #1502