### PR TITLE
fix: exclude blacksmith iron from soul shard data

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/BlacksmithFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/BlacksmithFamiliarEntity.java
@@ -176,6 +176,11 @@ public class BlacksmithFamiliarEntity extends FamiliarEntity {
     }
 
     @Override
+    protected void removeDataFromSoulShard(net.minecraft.nbt.CompoundTag entityData) {
+        entityData.remove("ironCount");
+    }
+
+    @Override
     public void readAdditionalSaveData(net.minecraft.world.level.storage.ValueInput input) {
         super.readAdditionalSaveData(input);
         this.setIronCount(input.getIntOr("ironCount", 0));

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/BlacksmithFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/BlacksmithFamiliarEntity.java
@@ -177,6 +177,7 @@ public class BlacksmithFamiliarEntity extends FamiliarEntity {
 
     @Override
     protected void removeDataFromSoulShard(net.minecraft.nbt.CompoundTag entityData) {
+        super.removeDataFromSoulShard(entityData);
         entityData.remove("ironCount");
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/FamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/FamiliarEntity.java
@@ -120,6 +120,7 @@ public abstract class FamiliarEntity extends PathfinderMob implements IFamiliar 
         var valueOutput = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, this.registryAccess());
         this.saveWithoutId(valueOutput);
         entityData.merge(valueOutput.buildResult());
+        this.removeDataFromSoulShard(entityData);
 
         shard.set(DataComponents.ENTITY_DATA, TypedEntityData.of(this.getType(), entityData));
 
@@ -140,6 +141,9 @@ public abstract class FamiliarEntity extends PathfinderMob implements IFamiliar 
     public void setRecordPlayingNearby(BlockPos jukeboxPos, boolean partying) {
         this.jukeboxPos = jukeboxPos;
         this.partying = partying;
+    }
+
+    protected void removeDataFromSoulShard(CompoundTag entityData) {
     }
 
     public boolean isPartying() {


### PR DESCRIPTION
## Summary
- strip blacksmith ironCount from soul shard entity data before the shard is created
- keep familiar soul shard serialization extensible with a subclass cleanup hook
- fix blacksmith resurrection so recovered iron cubes are not duplicated

Closes #1488