### PR TITLE
fix: re-register machine operators after storage upgrades

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/ManageMachineJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/ManageMachineJob.java
@@ -99,7 +99,7 @@ public class ManageMachineJob extends SpiritJob {
     }
 
     public IStorageController getStorageController() {
-        return this.resolveCurrentStorageController(true);
+        return this.resolveCurrentStorageController();
     }
 
     public BlockEntity getManagedMachineBlockEntity() {
@@ -155,6 +155,8 @@ public class ManageMachineJob extends SpiritJob {
     public void update() {
         //we are basically inactive until we have both a storage controller and a managed machine.
         if (this.storageControllerPosition != null && this.managedMachine != null) {
+            this.refreshStorageControllerRegistration();
+
             //if we don't have an order and there is one available, take it from queue.
             if (this.getCurrentDepositOrder() == null && !this.depositOrderQueue.isEmpty()) {
                 this.setCurrentDepositOrder(this.depositOrderQueue.poll());
@@ -221,7 +223,7 @@ public class ManageMachineJob extends SpiritJob {
             return;
         }
 
-        IStorageController storageController = this.resolveCurrentStorageController(false);
+        IStorageController storageController = this.resolveCurrentStorageController();
         if (storageController != null) {
             this.registerWithStorageController(storageController);
         }
@@ -229,13 +231,21 @@ public class ManageMachineJob extends SpiritJob {
 
     protected void unregisterFromStorageController() {
         if (this.storageControllerPosition != null && this.managedMachine != null && BlockEntityUtil.isLoaded(this.entity.level(), this.storageControllerPosition)) {
-            IStorageController storageController = this.resolveCurrentStorageController(false);
+            IStorageController storageController = this.resolveCurrentStorageController();
             if (storageController != null)
                 storageController.removeDepositOrderSpirit(this.managedMachine.insertGlobalPos);
         }
     }
 
-    protected IStorageController resolveCurrentStorageController(boolean reRegisterIfChanged) {
+    protected void refreshStorageControllerRegistration() {
+        IStorageController previousStorageController = this.storageController;
+        IStorageController currentStorageController = this.resolveCurrentStorageController();
+        if (currentStorageController != null && currentStorageController != previousStorageController) {
+            this.registerWithStorageController(currentStorageController);
+        }
+    }
+
+    protected IStorageController resolveCurrentStorageController() {
         if (this.storageControllerPosition == null)
             return null;
 
@@ -250,14 +260,8 @@ public class ManageMachineJob extends SpiritJob {
             return null;
         }
 
-        if (this.storageController != currentStorageController) {
-            this.storageController = currentStorageController;
-            if (reRegisterIfChanged) {
-                this.registerWithStorageController(currentStorageController);
-            }
-        }
-
-        return this.storageController;
+        this.storageController = currentStorageController;
+        return currentStorageController;
     }
 
     protected void registerWithStorageController(IStorageController storageController) {

--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/ManageMachineJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/ManageMachineJob.java
@@ -99,17 +99,7 @@ public class ManageMachineJob extends SpiritJob {
     }
 
     public IStorageController getStorageController() {
-        if (this.storageControllerPosition == null)
-            return null;
-
-        if (this.storageController == null) {
-            this.storageController = (IStorageController) BlockEntityUtil.get(this.entity.level(),
-                    this.storageControllerPosition);
-        }
-
-        if (this.storageController == null)
-            this.storageControllerPosition = null;
-        return this.storageController;
+        return this.resolveCurrentStorageController(true);
     }
 
     public BlockEntity getManagedMachineBlockEntity() {
@@ -227,20 +217,54 @@ public class ManageMachineJob extends SpiritJob {
     }
 
     protected void registerWithStorageController() {
-        IStorageController storageController = this.getStorageController();
+        if (this.storageControllerPosition == null || !BlockEntityUtil.isLoaded(this.entity.level(), this.storageControllerPosition)) {
+            return;
+        }
 
-        if (storageController != null && this.managedMachine != null) {
-            storageController.addDepositOrderSpirit(this.managedMachine.insertGlobalPos, this.entity.getUUID());
-            storageController.linkMachine(this.managedMachine);
-            BlockEntityUtil.updateTile(this.entity.level(), this.getStorageControllerPosition().getPos());
+        IStorageController storageController = this.resolveCurrentStorageController(false);
+        if (storageController != null) {
+            this.registerWithStorageController(storageController);
         }
     }
 
     protected void unregisterFromStorageController() {
-        if (this.storageControllerPosition != null && this.managedMachine != null) {
-            IStorageController storageController = this.getStorageController();
+        if (this.storageControllerPosition != null && this.managedMachine != null && BlockEntityUtil.isLoaded(this.entity.level(), this.storageControllerPosition)) {
+            IStorageController storageController = this.resolveCurrentStorageController(false);
             if (storageController != null)
                 storageController.removeDepositOrderSpirit(this.managedMachine.insertGlobalPos);
+        }
+    }
+
+    protected IStorageController resolveCurrentStorageController(boolean reRegisterIfChanged) {
+        if (this.storageControllerPosition == null)
+            return null;
+
+        if (!BlockEntityUtil.isLoaded(this.entity.level(), this.storageControllerPosition)) {
+            return this.storageController;
+        }
+
+        BlockEntity blockEntity = BlockEntityUtil.get(this.entity.level(), this.storageControllerPosition);
+        if (!(blockEntity instanceof IStorageController currentStorageController)) {
+            this.storageController = null;
+            this.storageControllerPosition = null;
+            return null;
+        }
+
+        if (this.storageController != currentStorageController) {
+            this.storageController = currentStorageController;
+            if (reRegisterIfChanged) {
+                this.registerWithStorageController(currentStorageController);
+            }
+        }
+
+        return this.storageController;
+    }
+
+    protected void registerWithStorageController(IStorageController storageController) {
+        if (this.managedMachine != null) {
+            storageController.addDepositOrderSpirit(this.managedMachine.insertGlobalPos, this.entity.getUUID());
+            storageController.linkMachine(this.managedMachine);
+            BlockEntityUtil.updateTile(this.entity.level(), this.getStorageControllerPosition().getPos());
         }
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/ManageMachineJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/ManageMachineJob.java
@@ -240,13 +240,13 @@ public class ManageMachineJob extends SpiritJob {
             return null;
 
         if (!BlockEntityUtil.isLoaded(this.entity.level(), this.storageControllerPosition)) {
-            return this.storageController;
+            this.storageController = null;
+            return null;
         }
 
         BlockEntity blockEntity = BlockEntityUtil.get(this.entity.level(), this.storageControllerPosition);
         if (!(blockEntity instanceof IStorageController currentStorageController)) {
             this.storageController = null;
-            this.storageControllerPosition = null;
             return null;
         }
 


### PR DESCRIPTION
## Summary
- refresh the cached storage controller in ManageMachineJob when the controller block entity is replaced
- re-register linked machine operator spirits after upgrading a storage actuator to the stabilized variant
- avoid writing registration state while the storage controller chunk is unloaded

Closes #1441
