### PR TITLE
fix: prevent EMI actuator autofill from deleting last item

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageSetRecipeByTemplate.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageSetRecipeByTemplate.java
@@ -101,9 +101,10 @@ public class MessageSetRecipeByTemplate implements IMessage {
                 ItemStack extractedStack = StorageUtil
                         .extractItem(new PlayerMainInvWrapper(player.getInventory()), ingredient, 1, true);
                 if (canAcceptIngredient(craftMatrix, slot, extractedStack)) {
+                    ItemStack acceptedStack = extractedStack.copy();
                     extractedStack = StorageUtil.extractItem(new PlayerMainInvWrapper(player.getInventory()), ingredient, 1, false);
                     if (!extractedStack.isEmpty()) {
-                        placeExtractedStack(craftMatrix, slot, extractedStack);
+                        placeExtractedStack(craftMatrix, slot, acceptedStack);
                         extractedAny = true;
                         continue;
                     }
@@ -111,9 +112,10 @@ public class MessageSetRecipeByTemplate implements IMessage {
 
                 extractedStack = storageController.getItemStack(ingredient, 1, true);
                 if (canAcceptIngredient(craftMatrix, slot, extractedStack)) {
+                    ItemStack acceptedStack = extractedStack.copy();
                     extractedStack = storageController.getItemStack(ingredient, 1, false);
                     if (!extractedStack.isEmpty()) {
-                        placeExtractedStack(craftMatrix, slot, extractedStack);
+                        placeExtractedStack(craftMatrix, slot, acceptedStack);
                         extractedAny = true;
                     }
                 }


### PR DESCRIPTION
## Summary
- preserve the simulated item stack when EMI autofill moves ingredients into the Dimensional Storage Actuator grid
- avoid losing the final matching item when the real extraction mutates the returned stack during the post-#1507 transfer flow
- keep the hang fix from #1507 while fixing the regression reported in #1518

Closes #1518