### PR TITLE
fix: prevent EMI actuator autofill from deleting last item

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageSetRecipeByTemplate.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageSetRecipeByTemplate.java
@@ -103,9 +103,10 @@ public class MessageSetRecipeByTemplate implements IMessage {
                         .extractItem(net.neoforged.neoforge.transfer.item.PlayerInventoryWrapper.of(player).getMainSlots(), ingredient,
                                 1, true);
                 if (this.canAcceptIngredient(craftMatrix, slot, extractedStack)) {
+                    ItemStack acceptedStack = extractedStack.copy();
                     extractedStack = StorageUtil.extractItem(net.neoforged.neoforge.transfer.item.PlayerInventoryWrapper.of(player).getMainSlots(), ingredient, 1, false);
                     if (!extractedStack.isEmpty()) {
-                        this.placeExtractedStack(craftMatrix, slot, extractedStack);
+                        this.placeExtractedStack(craftMatrix, slot, acceptedStack);
                         anyExtracted = true;
                         continue;
                     }
@@ -114,9 +115,10 @@ public class MessageSetRecipeByTemplate implements IMessage {
                 //if we did not find anything in the player inventory, get it from the network now
                 extractedStack = storageController.getItemStack(ingredient, 1, true);
                 if (this.canAcceptIngredient(craftMatrix, slot, extractedStack)) {
+                    ItemStack acceptedStack = extractedStack.copy();
                     extractedStack = storageController.getItemStack(ingredient, 1, false);
                     if (!extractedStack.isEmpty()) {
-                        this.placeExtractedStack(craftMatrix, slot, extractedStack);
+                        this.placeExtractedStack(craftMatrix, slot, acceptedStack);
                         anyExtracted = true;
                     }
                 }


### PR DESCRIPTION
## Summary
- preserve the simulated item stack when EMI autofill moves ingredients into the Dimensional Storage Actuator grid on the 26.1 line
- avoid losing the final matching item when the real extraction mutates the returned stack during the post-#1507 transfer flow
- forward-port the fix from #1519 to version/26.1

Closes #1518