### PR TITLE
fix: validate open satchels by stack UUID

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/AbstractSatchelContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/AbstractSatchelContainer.java
@@ -23,6 +23,7 @@
 package com.klikli_dev.occultism.common.container.satchel;
 
 import com.klikli_dev.occultism.registry.OccultismItems;
+import com.klikli_dev.occultism.util.ItemNBTUtil;
 import com.klikli_dev.occultism.util.CuriosUtil;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
@@ -33,25 +34,21 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 
 import javax.annotation.Nullable;
+import java.util.UUID;
 
 public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
 
     protected Container satchelInventory;
     protected Inventory playerInventory;
     protected int selectedSlot;
-    protected ItemStack satchelStack;
+    protected UUID satchelUUID;
 
-    public AbstractSatchelContainer(@Nullable MenuType<?> menuType, int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
+    public AbstractSatchelContainer(@Nullable MenuType<?> menuType, int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUUID) {
         super(menuType, id);
         this.satchelInventory = satchelInventory;
         this.playerInventory = playerInventory;
         this.selectedSlot = selectedSlot;
-
-        if (this.selectedSlot == -1) {
-            this.satchelStack = CuriosUtil.getBackpack(playerInventory.player);
-        } else {
-            this.satchelStack = playerInventory.player.getInventory().getItem(this.selectedSlot).copy();
-        }
+        this.satchelUUID = satchelUUID;
 
 
         this.setupSatchelSlots();
@@ -105,12 +102,23 @@ public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
+        ItemStack currentSatchelStack;
         if (this.selectedSlot == -1) {
-            return CuriosUtil.getBackpack(player).getItem() == this.satchelStack.getItem();
+            currentSatchelStack = CuriosUtil.getBackpack(player);
+        } else {
+            if (this.selectedSlot < 0 || this.selectedSlot >= player.getInventory().getContainerSize())
+                return false;
+            currentSatchelStack = player.getInventory().getItem(this.selectedSlot);
         }
-        if (this.selectedSlot < 0 || this.selectedSlot >= player.getInventory().getContainerSize())
+
+        if (currentSatchelStack.isEmpty())
             return false;
-        return player.getInventory().getItem(this.selectedSlot).getItem() == this.satchelStack.getItem();
+
+        UUID currentSatchelUUID = player.level().isClientSide() ? ItemNBTUtil.getSatchelUUID(currentSatchelStack) : ItemNBTUtil.getOrCreateSatchelUUID(player.level(), currentSatchelStack);
+        if (currentSatchelUUID == null && player.level().isClientSide())
+            return true;
+
+        return this.satchelUUID.equals(currentSatchelUUID);
     }
 
     protected void setupPlayerInventorySlots() {

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelContainer.java
@@ -6,12 +6,13 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 
 import javax.annotation.Nullable;
+import java.util.UUID;
 
 public abstract class RitualSatchelContainer extends AbstractSatchelContainer {
     public static final int SATCHEL_SIZE = 4 * 9;
 
-    public RitualSatchelContainer(@Nullable MenuType<?> menuType, int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
-        super(menuType, id, playerInventory, satchelInventory, selectedSlot);
+    public RitualSatchelContainer(@Nullable MenuType<?> menuType, int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUUID) {
+        super(menuType, id, playerInventory, satchelInventory, selectedSlot, satchelUUID);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT1Container.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT1Container.java
@@ -6,13 +6,16 @@ import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 
+import java.util.UUID;
+
 public class RitualSatchelT1Container extends RitualSatchelContainer {
-    public RitualSatchelT1Container(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
-        super(OccultismContainers.RITUAL_SATCHEL_T1.get(), id, playerInventory, satchelInventory, selectedSlot);
+    public RitualSatchelT1Container(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUUID) {
+        super(OccultismContainers.RITUAL_SATCHEL_T1.get(), id, playerInventory, satchelInventory, selectedSlot, satchelUUID);
     }
 
     public static RitualSatchelT1Container createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        return new RitualSatchelT1Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot);
+        final UUID satchelUUID = new UUID(buffer.readLong(), buffer.readLong());
+        return new RitualSatchelT1Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot, satchelUUID);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT1Container.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT1Container.java
@@ -15,7 +15,7 @@ public class RitualSatchelT1Container extends RitualSatchelContainer {
 
     public static RitualSatchelT1Container createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        final UUID satchelUUID = new UUID(buffer.readLong(), buffer.readLong());
+        final UUID satchelUUID = buffer.readUUID();
         return new RitualSatchelT1Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot, satchelUUID);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT2Container.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT2Container.java
@@ -6,13 +6,16 @@ import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 
+import java.util.UUID;
+
 public class RitualSatchelT2Container extends RitualSatchelContainer {
-    public RitualSatchelT2Container(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
-        super(OccultismContainers.RITUAL_SATCHEL_T2.get(), id, playerInventory, satchelInventory, selectedSlot);
+    public RitualSatchelT2Container(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUUID) {
+        super(OccultismContainers.RITUAL_SATCHEL_T2.get(), id, playerInventory, satchelInventory, selectedSlot, satchelUUID);
     }
 
     public static RitualSatchelT2Container createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        return new RitualSatchelT2Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot);
+        final UUID satchelUUID = new UUID(buffer.readLong(), buffer.readLong());
+        return new RitualSatchelT2Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot, satchelUUID);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT2Container.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT2Container.java
@@ -15,7 +15,7 @@ public class RitualSatchelT2Container extends RitualSatchelContainer {
 
     public static RitualSatchelT2Container createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        final UUID satchelUUID = new UUID(buffer.readLong(), buffer.readLong());
+        final UUID satchelUUID = buffer.readUUID();
         return new RitualSatchelT2Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot, satchelUUID);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/StorageSatchelContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/StorageSatchelContainer.java
@@ -7,16 +7,19 @@ import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
 
+import java.util.UUID;
+
 public class StorageSatchelContainer extends AbstractSatchelContainer {
     public static final int SATCHEL_SIZE = 13 * 9;
 
-    public StorageSatchelContainer(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
-        super(OccultismContainers.SATCHEL.get(), id, playerInventory, satchelInventory, selectedSlot);
+    public StorageSatchelContainer(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUUID) {
+        super(OccultismContainers.SATCHEL.get(), id, playerInventory, satchelInventory, selectedSlot, satchelUUID);
     }
 
     public static StorageSatchelContainer createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        return new StorageSatchelContainer(id, playerInventory, new SimpleContainer(SATCHEL_SIZE), selectedSlot);
+        final UUID satchelUUID = new UUID(buffer.readLong(), buffer.readLong());
+        return new StorageSatchelContainer(id, playerInventory, new SimpleContainer(SATCHEL_SIZE), selectedSlot, satchelUUID);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/StorageSatchelContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/StorageSatchelContainer.java
@@ -18,7 +18,7 @@ public class StorageSatchelContainer extends AbstractSatchelContainer {
 
     public static StorageSatchelContainer createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        final UUID satchelUUID = new UUID(buffer.readLong(), buffer.readLong());
+        final UUID satchelUUID = buffer.readUUID();
         return new StorageSatchelContainer(id, playerInventory, new SimpleContainer(SATCHEL_SIZE), selectedSlot, satchelUUID);
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/storage/SatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/storage/SatchelItem.java
@@ -61,8 +61,7 @@ public class SatchelItem extends Item {
                                 this.getInventory((ServerPlayer) player, stack), selectedSlot, satchelUUID);
                     }, stack.getDisplayName()), buffer -> {
                         buffer.writeVarInt(selectedSlot);
-                        buffer.writeLong(satchelUUID.getMostSignificantBits());
-                        buffer.writeLong(satchelUUID.getLeastSignificantBits());
+                        buffer.writeUUID(satchelUUID);
                     });
         }
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/storage/SatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/storage/SatchelItem.java
@@ -36,6 +36,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.level.Level;
 
+import java.util.UUID;
 import java.util.function.Consumer;
 
 public class SatchelItem extends Item {
@@ -52,13 +53,16 @@ public class SatchelItem extends Item {
         if (!level.isClientSide() && player instanceof ServerPlayer serverPlayer) {
             //here we use main hand item as selected slot
             int selectedSlot = hand == InteractionHand.MAIN_HAND ? player.getInventory().getSelectedSlot() : -1;
+            UUID satchelUUID = ItemNBTUtil.getOrCreateSatchelUUID(level, stack);
 
             serverPlayer.openMenu(
                     new SimpleMenuProvider((id, playerInventory, unused) -> {
                         return new StorageSatchelContainer(id, playerInventory,
-                                this.getInventory((ServerPlayer) player, stack), selectedSlot);
+                                this.getInventory((ServerPlayer) player, stack), selectedSlot, satchelUUID);
                     }, stack.getDisplayName()), buffer -> {
                         buffer.writeVarInt(selectedSlot);
+                        buffer.writeLong(satchelUUID.getMostSignificantBits());
+                        buffer.writeLong(satchelUUID.getLeastSignificantBits());
                     });
         }
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/MultiBlockRitualSatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/MultiBlockRitualSatchelItem.java
@@ -13,7 +13,6 @@ import com.klikli_dev.occultism.registry.OccultismTags;
 import com.klikli_dev.occultism.util.ItemNBTUtil;
 import com.klikli_dev.occultism.common.container.satchel.SatchelInventory;
 import com.klikli_dev.occultism.util.TextUtil;
-import com.mojang.datafixers.util.Function4;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.component.DataComponents;
@@ -36,6 +35,7 @@ import com.klikli_dev.occultism.util.ItemTransferUtil;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.item.component.ItemContainerContents;
 
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -49,8 +49,8 @@ public class MultiBlockRitualSatchelItem extends RitualSatchelItem {
     }
 
     @Override
-    protected Function4<Integer, Inventory, Container, Integer, AbstractContainerMenu> containerFactory() {
-        return RitualSatchelT2Container::new;
+    protected AbstractContainerMenu createContainer(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUUID) {
+        return new RitualSatchelT2Container(id, playerInventory, satchelInventory, selectedSlot, satchelUUID);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/RitualSatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/RitualSatchelItem.java
@@ -64,8 +64,7 @@ public abstract class RitualSatchelItem extends Item {
                     return this.createContainer(id, playerInventory, this.getInventory(player, stack), selectedSlot, satchelUUID);
                 }, stack.getDisplayName()), buffer -> {
                     buffer.writeVarInt(selectedSlot);
-                    buffer.writeLong(satchelUUID.getMostSignificantBits());
-                    buffer.writeLong(satchelUUID.getLeastSignificantBits());
+                    buffer.writeUUID(satchelUUID);
                 });
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/RitualSatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/RitualSatchelItem.java
@@ -11,7 +11,7 @@ import com.klikli_dev.occultism.common.item.tool.ChalkItem;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSendPreviewedPentacle;
 import com.klikli_dev.occultism.registry.OccultismItems;
-import com.mojang.datafixers.util.Function4;
+import com.klikli_dev.occultism.util.ItemNBTUtil;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMaps;
 import net.minecraft.ChatFormatting;
@@ -57,12 +57,15 @@ public abstract class RitualSatchelItem extends Item {
 
     protected void openMenu(ServerPlayer player, ItemStack stack) {
         int selectedSlot = player.getInventory().getSelectedSlot();
+        UUID satchelUUID = ItemNBTUtil.getOrCreateSatchelUUID(player.level(), stack);
 
         player.openMenu(
                 new SimpleMenuProvider((id, playerInventory, unused) -> {
-                    return this.containerFactory().apply(id, playerInventory, this.getInventory(player, stack), selectedSlot);
+                    return this.createContainer(id, playerInventory, this.getInventory(player, stack), selectedSlot, satchelUUID);
                 }, stack.getDisplayName()), buffer -> {
                     buffer.writeVarInt(selectedSlot);
+                    buffer.writeLong(satchelUUID.getMostSignificantBits());
+                    buffer.writeLong(satchelUUID.getLeastSignificantBits());
                 });
     }
 
@@ -163,7 +166,7 @@ public abstract class RitualSatchelItem extends Item {
         return InteractionResult.SUCCESS;
     }
 
-    protected abstract Function4<Integer, Inventory, Container, Integer, AbstractContainerMenu> containerFactory();
+    protected abstract AbstractContainerMenu createContainer(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUUID);
 
     protected abstract InteractionResult useOnServerSide(UseOnContext context);
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/SingleBlockRitualSatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/SingleBlockRitualSatchelItem.java
@@ -5,7 +5,6 @@ import com.klikli_dev.occultism.TranslationKeys;
 import com.klikli_dev.occultism.common.container.satchel.RitualSatchelT1Container;
 import com.klikli_dev.occultism.util.ItemNBTUtil;
 import com.klikli_dev.occultism.util.TextUtil;
-import com.mojang.datafixers.util.Function4;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.Container;
@@ -18,6 +17,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.item.context.UseOnContext;
 
+import java.util.UUID;
 import java.util.function.Consumer;
 
 /**
@@ -30,8 +30,8 @@ public class SingleBlockRitualSatchelItem extends RitualSatchelItem {
     }
 
     @Override
-    protected Function4<Integer, Inventory, Container, Integer, AbstractContainerMenu> containerFactory() {
-        return RitualSatchelT1Container::new;
+    protected AbstractContainerMenu createContainer(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUUID) {
+        return new RitualSatchelT1Container(id, playerInventory, satchelInventory, selectedSlot, satchelUUID);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
@@ -77,8 +77,7 @@ public class MessageOpenSatchel implements IMessage {
                                 finalSelectedSlot, satchelUUID);
                     }, backpackStack.getDisplayName()), buffer -> {
                         buffer.writeVarInt(finalSelectedSlot);
-                        buffer.writeLong(satchelUUID.getMostSignificantBits());
-                        buffer.writeLong(satchelUUID.getLeastSignificantBits());
+                        buffer.writeUUID(satchelUUID);
                     });
         }
     }

--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
@@ -27,6 +27,7 @@ import com.klikli_dev.occultism.common.container.satchel.StorageSatchelContainer
 import com.klikli_dev.occultism.common.item.storage.SatchelItem;
 import com.klikli_dev.occultism.network.IMessage;
 import com.klikli_dev.occultism.util.CuriosUtil;
+import com.klikli_dev.occultism.util.ItemNBTUtil;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -35,6 +36,8 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.item.ItemStack;
+
+import java.util.UUID;
 
 public class MessageOpenSatchel implements IMessage {
 
@@ -60,19 +63,22 @@ public class MessageOpenSatchel implements IMessage {
         //if not found, try to get from player inventory
         if (!(backpackStack.getItem() instanceof SatchelItem)) {
             selectedSlot = CuriosUtil.getFirstBackpackSlot(player);
-            backpackStack = selectedSlot > 0 ? player.getInventory().getItem(selectedSlot) : ItemStack.EMPTY;
+            backpackStack = selectedSlot >= 0 ? player.getInventory().getItem(selectedSlot) : ItemStack.EMPTY;
         }
         //now, if we have a satchel, proceed
         if (backpackStack.getItem() instanceof SatchelItem) {
+            UUID satchelUUID = ItemNBTUtil.getOrCreateSatchelUUID(player.level(), backpackStack);
             ItemStack finalBackpackStack = backpackStack;
             int finalSelectedSlot = selectedSlot;
             player.openMenu(
                     new SimpleMenuProvider((id, playerInventory, unused) -> {
                         return new StorageSatchelContainer(id, playerInventory,
                                 ((SatchelItem) finalBackpackStack.getItem()).getInventory(player, finalBackpackStack),
-                                finalSelectedSlot);
+                                finalSelectedSlot, satchelUUID);
                     }, backpackStack.getDisplayName()), buffer -> {
                         buffer.writeVarInt(finalSelectedSlot);
+                        buffer.writeLong(satchelUUID.getMostSignificantBits());
+                        buffer.writeLong(satchelUUID.getLeastSignificantBits());
                     });
         }
     }

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
@@ -241,6 +241,12 @@ public class OccultismDataComponents {
             .cacheEncoding()
     );
 
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<UUID>> SATCHEL_UUID = DATA_COMPONENTS.registerComponentType("satchel_uuid", builder -> builder
+            .persistent(OccultismExtraCodecs.UUID)
+            .networkSynchronized(OccultismExtraStreamCodecs.UUID)
+            .cacheEncoding()
+    );
+
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<String>> LINKED_PLAYER_NAME = DATA_COMPONENTS.registerComponentType("linked_player_name", builder -> builder
             .persistent(Codec.STRING)
             .networkSynchronized(ByteBufCodecs.STRING_UTF8)

--- a/src/main/java/com/klikli_dev/occultism/util/ItemNBTUtil.java
+++ b/src/main/java/com/klikli_dev/occultism/util/ItemNBTUtil.java
@@ -33,6 +33,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.level.Level;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -284,6 +285,26 @@ public class ItemNBTUtil {
             return null;
 
         return stack.get(OccultismDataComponents.LINKED_PLAYER_UUID);
+    }
+
+    public static UUID getSatchelUUID(ItemStack stack) {
+        if (!stack.has(OccultismDataComponents.SATCHEL_UUID))
+            return null;
+
+        return stack.get(OccultismDataComponents.SATCHEL_UUID);
+    }
+
+    public static UUID getOrCreateSatchelUUID(Level level, ItemStack stack) {
+        if (level.isClientSide())
+            throw new IllegalStateException("Satchel UUIDs may only be created on the server.");
+
+        UUID satchelUUID = getSatchelUUID(stack);
+        if (satchelUUID != null)
+            return satchelUUID;
+
+        satchelUUID = UUID.randomUUID();
+        stack.set(OccultismDataComponents.SATCHEL_UUID, satchelUUID);
+        return satchelUUID;
     }
 
     public static void setLinkedPlayerUUID(ItemStack stack, UUID id) {


### PR DESCRIPTION
## Summary
- add a dedicated satchel UUID data component and assign it server-side when a satchel is opened without one
- pass the satchel UUID through satchel menu opening so open container validation tracks the exact stack in the selected slot
- keep legacy satchels opening cleanly while their new UUID syncs to the client