### PR TITLE
fix: validate open satchels by stack UUID

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/AbstractSatchelContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/AbstractSatchelContainer.java
@@ -32,6 +32,8 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 
+import java.util.UUID;
+
 import javax.annotation.Nullable;
 
 public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
@@ -40,12 +42,14 @@ public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
     protected Inventory playerInventory;
     protected int selectedSlot;
     protected ItemStack satchelStack;
+    protected UUID satchelUuid;
 
-    public AbstractSatchelContainer(@Nullable MenuType<?> menuType, int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
+    public AbstractSatchelContainer(@Nullable MenuType<?> menuType, int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUuid) {
         super(menuType, id);
         this.satchelInventory = satchelInventory;
         this.playerInventory = playerInventory;
         this.selectedSlot = selectedSlot;
+        this.satchelUuid = satchelUuid;
 
         if (this.selectedSlot == -1) {
             this.satchelStack = CuriosUtil.getBackpack(playerInventory.player);
@@ -105,12 +109,22 @@ public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
+        ItemStack stack = ItemStack.EMPTY;
         if (this.selectedSlot == -1) {
-            return CuriosUtil.getBackpack(player).getItem() == this.satchelStack.getItem();
+            stack = CuriosUtil.getBackpack(player);
+        } else if (this.selectedSlot >= 0 && this.selectedSlot < player.getInventory().getContainerSize()) {
+            stack = player.getInventory().getItem(this.selectedSlot);
         }
-        if (this.selectedSlot < 0 || this.selectedSlot >= player.getInventory().getContainerSize())
+
+        if (stack.isEmpty() || stack.getItem() != this.satchelStack.getItem())
             return false;
-        return player.getInventory().getItem(this.selectedSlot).getItem() == this.satchelStack.getItem();
+
+        var currentUuid = stack.get(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID);
+        if (player.level().isClientSide) {
+            return currentUuid == null || currentUuid.equals(this.satchelUuid);
+        }
+
+        return currentUuid != null && currentUuid.equals(this.satchelUuid);
     }
 
     protected void setupPlayerInventorySlots() {

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelContainer.java
@@ -5,13 +5,15 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 
+import java.util.UUID;
+
 import javax.annotation.Nullable;
 
 public abstract class RitualSatchelContainer extends AbstractSatchelContainer {
     public static final int SATCHEL_SIZE = 4 * 9;
 
-    public RitualSatchelContainer(@Nullable MenuType<?> menuType, int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
-        super(menuType, id, playerInventory, satchelInventory, selectedSlot);
+    public RitualSatchelContainer(@Nullable MenuType<?> menuType, int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUuid) {
+        super(menuType, id, playerInventory, satchelInventory, selectedSlot, satchelUuid);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT1Container.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT1Container.java
@@ -6,13 +6,16 @@ import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 
+import java.util.UUID;
+
 public class RitualSatchelT1Container extends RitualSatchelContainer {
-    public RitualSatchelT1Container(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
-        super(OccultismContainers.RITUAL_SATCHEL_T1.get(), id, playerInventory, satchelInventory, selectedSlot);
+    public RitualSatchelT1Container(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUuid) {
+        super(OccultismContainers.RITUAL_SATCHEL_T1.get(), id, playerInventory, satchelInventory, selectedSlot, satchelUuid);
     }
 
-    public static RitualSatchelT1Container createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
+    public static RitualSatchelT1Container createClientContainer(int id, Inventory playerInventory, net.minecraft.network.RegistryFriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        return new RitualSatchelT1Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot);
+        final UUID satchelUuid = buffer.readUUID();
+        return new RitualSatchelT1Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot, satchelUuid);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT2Container.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/RitualSatchelT2Container.java
@@ -6,13 +6,16 @@ import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 
+import java.util.UUID;
+
 public class RitualSatchelT2Container extends RitualSatchelContainer {
-    public RitualSatchelT2Container(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
-        super(OccultismContainers.RITUAL_SATCHEL_T2.get(), id, playerInventory, satchelInventory, selectedSlot);
+    public RitualSatchelT2Container(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUuid) {
+        super(OccultismContainers.RITUAL_SATCHEL_T2.get(), id, playerInventory, satchelInventory, selectedSlot, satchelUuid);
     }
 
-    public static RitualSatchelT2Container createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
+    public static RitualSatchelT2Container createClientContainer(int id, Inventory playerInventory, net.minecraft.network.RegistryFriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        return new RitualSatchelT2Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot);
+        final UUID satchelUuid = buffer.readUUID();
+        return new RitualSatchelT2Container(id, playerInventory, new SimpleContainer(RitualSatchelContainer.SATCHEL_SIZE), selectedSlot, satchelUuid);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/StorageSatchelContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/StorageSatchelContainer.java
@@ -7,16 +7,19 @@ import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
 
+import java.util.UUID;
+
 public class StorageSatchelContainer extends AbstractSatchelContainer {
     public static final int SATCHEL_SIZE = 13 * 9;
 
-    public StorageSatchelContainer(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot) {
-        super(OccultismContainers.SATCHEL.get(), id, playerInventory, satchelInventory, selectedSlot);
+    public StorageSatchelContainer(int id, Inventory playerInventory, Container satchelInventory, int selectedSlot, UUID satchelUuid) {
+        super(OccultismContainers.SATCHEL.get(), id, playerInventory, satchelInventory, selectedSlot, satchelUuid);
     }
 
-    public static StorageSatchelContainer createClientContainer(int id, Inventory playerInventory, FriendlyByteBuf buffer) {
+    public static StorageSatchelContainer createClientContainer(int id, Inventory playerInventory, net.minecraft.network.RegistryFriendlyByteBuf buffer) {
         final int selectedSlot = buffer.readVarInt();
-        return new StorageSatchelContainer(id, playerInventory, new SimpleContainer(SATCHEL_SIZE), selectedSlot);
+        final UUID satchelUuid = buffer.readUUID();
+        return new StorageSatchelContainer(id, playerInventory, new SimpleContainer(SATCHEL_SIZE), selectedSlot, satchelUuid);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/item/storage/SatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/storage/SatchelItem.java
@@ -52,12 +52,18 @@ public class SatchelItem extends Item {
             //here we use main hand item as selected slot
             int selectedSlot = hand == InteractionHand.MAIN_HAND ? player.getInventory().selected : -1;
 
+            if (!stack.has(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID)) {
+                stack.set(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID, java.util.UUID.randomUUID());
+            }
+            java.util.UUID satchelUuid = stack.get(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID);
+
             serverPlayer.openMenu(
                     new SimpleMenuProvider((id, playerInventory, unused) -> {
                         return new StorageSatchelContainer(id, playerInventory,
-                                this.getInventory((ServerPlayer) player, stack), selectedSlot);
+                                this.getInventory((ServerPlayer) player, stack), selectedSlot, satchelUuid);
                     }, stack.getDisplayName()), buffer -> {
                         buffer.writeVarInt(selectedSlot);
+                        buffer.writeUUID(satchelUuid);
                     });
         }
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/MultiBlockRitualSatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/MultiBlockRitualSatchelItem.java
@@ -11,7 +11,7 @@ import com.klikli_dev.occultism.registry.OccultismRecipes;
 import com.klikli_dev.occultism.registry.OccultismTags;
 import com.klikli_dev.occultism.util.ItemNBTUtil;
 import com.klikli_dev.occultism.util.TextUtil;
-import com.mojang.datafixers.util.Function4;
+import com.mojang.datafixers.util.Function5;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.component.DataComponents;
@@ -31,6 +31,7 @@ import net.neoforged.neoforge.items.ComponentItemHandler;
 import net.neoforged.neoforge.items.ItemHandlerHelper;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -43,7 +44,7 @@ public class MultiBlockRitualSatchelItem extends RitualSatchelItem {
     }
 
     @Override
-    protected Function4<Integer, Inventory, Container, Integer, AbstractContainerMenu> containerFactory() {
+    protected Function5<Integer, Inventory, Container, Integer, UUID, AbstractContainerMenu> containerFactory() {
         return RitualSatchelT2Container::new;
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/RitualSatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/RitualSatchelItem.java
@@ -11,7 +11,7 @@ import com.klikli_dev.occultism.common.item.tool.ChalkItem;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSendPreviewedPentacle;
 import com.klikli_dev.occultism.registry.OccultismItems;
-import com.mojang.datafixers.util.Function4;
+import com.mojang.datafixers.util.Function5;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMaps;
 import net.minecraft.ChatFormatting;
@@ -56,11 +56,17 @@ public abstract class RitualSatchelItem extends Item {
     protected void openMenu(ServerPlayer player, ItemStack stack) {
         int selectedSlot = player.getInventory().selected;
 
+        if (!stack.has(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID)) {
+            stack.set(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID, UUID.randomUUID());
+        }
+        UUID satchelUuid = stack.get(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID);
+
         player.openMenu(
                 new SimpleMenuProvider((id, playerInventory, unused) -> {
-                    return this.containerFactory().apply(id, playerInventory, this.getInventory(player, stack), selectedSlot);
+                    return this.containerFactory().apply(id, playerInventory, this.getInventory(player, stack), selectedSlot, satchelUuid);
                 }, stack.getDisplayName()), buffer -> {
                     buffer.writeVarInt(selectedSlot);
+                    buffer.writeUUID(satchelUuid);
                 });
     }
 
@@ -164,7 +170,7 @@ public abstract class RitualSatchelItem extends Item {
         return InteractionResult.SUCCESS;
     }
 
-    protected abstract Function4<Integer, Inventory, Container, Integer, AbstractContainerMenu> containerFactory();
+    protected abstract Function5<Integer, Inventory, Container, Integer, UUID, AbstractContainerMenu> containerFactory();
 
     protected abstract InteractionResult useOnServerSide(UseOnContext context);
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/SingleBlockRitualSatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/SingleBlockRitualSatchelItem.java
@@ -5,7 +5,7 @@ import com.klikli_dev.occultism.TranslationKeys;
 import com.klikli_dev.occultism.common.container.satchel.RitualSatchelT1Container;
 import com.klikli_dev.occultism.util.ItemNBTUtil;
 import com.klikli_dev.occultism.util.TextUtil;
-import com.mojang.datafixers.util.Function4;
+import com.mojang.datafixers.util.Function5;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.Container;
@@ -17,6 +17,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Places a single block of a ritual multiblock.
@@ -28,7 +29,7 @@ public class SingleBlockRitualSatchelItem extends RitualSatchelItem {
     }
 
     @Override
-    protected Function4<Integer, Inventory, Container, Integer, AbstractContainerMenu> containerFactory() {
+    protected Function5<Integer, Inventory, Container, Integer, UUID, AbstractContainerMenu> containerFactory() {
         return RitualSatchelT1Container::new;
     }
 

--- a/src/main/java/com/klikli_dev/occultism/handlers/ClientPlayerEventHandler.java
+++ b/src/main/java/com/klikli_dev/occultism/handlers/ClientPlayerEventHandler.java
@@ -98,7 +98,7 @@ public class ClientPlayerEventHandler {
     public static void checkBackpackKey() {
         Minecraft minecraft = Minecraft.getInstance();
         if (minecraft.player != null & minecraft.screen == null && ClientSetupEventHandler.KEY_BACKPACK.consumeClick()
-                && (!CuriosUtil.getBackpack(minecraft.player).isEmpty() || CuriosUtil.getFirstBackpackSlot(minecraft.player) > 0)) {
+                && (!CuriosUtil.getBackpack(minecraft.player).isEmpty() || CuriosUtil.getFirstBackpackSlot(minecraft.player) >= 0)) {
             Networking.sendToServer(new MessageOpenSatchel());
             minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.ARMOR_EQUIP_LEATHER.value(), 0.75F, 1.0F));
         }

--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
@@ -36,6 +36,8 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.item.ItemStack;
 
+import java.util.UUID;
+
 public class MessageOpenSatchel implements IMessage {
 
     public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "open_satchel");
@@ -60,19 +62,25 @@ public class MessageOpenSatchel implements IMessage {
         //if not found, try to get from player inventory
         if (!(backpackStack.getItem() instanceof SatchelItem)) {
             selectedSlot = CuriosUtil.getFirstBackpackSlot(player);
-            backpackStack = selectedSlot > 0 ? player.getInventory().getItem(selectedSlot) : ItemStack.EMPTY;
+            backpackStack = selectedSlot >= 0 ? player.getInventory().getItem(selectedSlot) : ItemStack.EMPTY;
         }
         //now, if we have a satchel, proceed
         if (backpackStack.getItem() instanceof SatchelItem) {
+            if (!backpackStack.has(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID)) {
+                backpackStack.set(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID, UUID.randomUUID());
+            }
+            UUID satchelUuid = backpackStack.get(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID);
+
             ItemStack finalBackpackStack = backpackStack;
             int finalSelectedSlot = selectedSlot;
             player.openMenu(
                     new SimpleMenuProvider((id, playerInventory, unused) -> {
                         return new StorageSatchelContainer(id, playerInventory,
                                 ((SatchelItem) finalBackpackStack.getItem()).getInventory(player, finalBackpackStack),
-                                finalSelectedSlot);
+                                finalSelectedSlot, satchelUuid);
                     }, backpackStack.getDisplayName()), buffer -> {
                         buffer.writeVarInt(finalSelectedSlot);
+                        buffer.writeUUID(satchelUuid);
                     });
         }
     }

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
@@ -270,4 +270,10 @@ public class OccultismDataComponents {
             .networkSynchronized(ByteBufCodecs.FLOAT)
             .cacheEncoding()
     );
+
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<UUID>> SATCHEL_UUID = DATA_COMPONENTS.registerComponentType("satchel_uuid", builder -> builder
+            .persistent(OccultismExtraCodecs.UUID)
+            .networkSynchronized(OccultismExtraStreamCodecs.UUID)
+            .cacheEncoding()
+    );
 }


### PR DESCRIPTION
## Summary
- validate open satchels against a per-stack SATCHEL_UUID instead of item type
- generate and sync satchel UUIDs when menus open so storage and ritual satchels keep tracking the exact stack that was opened
- include the review follow-up by making stillValid() read-only and fixing the client backpack key path to accept slot 0