### PR TITLE
fix: preserve exact-stack EMI autofill items (#1521)

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/util/StorageUtil.java
+++ b/src/main/java/com/klikli_dev/occultism/util/StorageUtil.java
@@ -163,7 +163,7 @@ public class StorageUtil {
 
                     //once we found enough, use the current slot to create a stack with the desired amount and return it
                     if (amountExtracted == amount)
-                        return slot.copyWithCount(amount);
+                        return extractedStack.copyWithCount(amount);
                     else
                         //continue extracting from this slot until we get nothing back.
                         i--;


### PR DESCRIPTION
## Summary
- Fix the shared inventory extraction helper used by EMI storage actuator autofill so exact-size hotbar stacks are preserved.
- Return the actually extracted stack instead of copying the pre-extraction slot view, matching the root cause behind the earlier #1519 fix.

## Testing
- `.\gradlew.bat compileJava`

Fixes #1521