### PR TITLE
fix: preserve exact-stack EMI autofill items (#1521)

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/util/StorageUtil.java
+++ b/src/main/java/com/klikli_dev/occultism/util/StorageUtil.java
@@ -171,7 +171,7 @@ public class StorageUtil {
 
                     //once we found enough, use the current slot to create a stack with the desired amount and return it
                     if (amountExtracted == amount)
-                        return slot.copyWithCount(amount);
+                        return extractedStack.copyWithCount(amount);
                     else
                         //continue extracting from this slot until we get nothing back.
                         i--;


### PR DESCRIPTION
## Summary
- backport PR #1524 to ersion/26.1
- return the actually extracted stack in StorageUtil.extractItem() so EMI autofill preserves exact-size hotbar stacks

## Testing
- .\gradlew.bat compileJava

Fixes #1521