### PR TITLE
refactor: replace spirit SmartBrainLib AI with vanilla brains

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -115,7 +115,6 @@ jobs:
           dependencies: |
             modonomicon(required)
             geckolib(required)
-            smartbrainlib(required)
             theurgy(optional)
             jei(optional)
             emi(optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,6 @@
 - MAKE CONVENTIONAL COMMITS FOR EVERY ATOMIC CHANGE.
 - For fixes and features always create a branch, and open a PR when ready. If given an issue to work on, link the issue in the PR description.
 - Read `build.gradle` and `gradle.properties`, and `src/main/resources/META-INF/neoforge.mods.toml` to find the current minecraft version used.
-- When updating, **never** change `gradle.properties`, a human will update it before you start work.
 - Do not guess vanilla API changes; verify them.
 
 ## Minecraft source lookups

--- a/build.gradle
+++ b/build.gradle
@@ -137,13 +137,6 @@ repositories {
         }
     }
     maven {
-        name = "SBL Maven"
-        url "https://dl.cloudsmith.io/public/tslat/sbl/maven/"
-        content {
-            includeGroup "net.tslat.smartbrainlib"
-        }
-    }
-    maven {
         url "https://cursemaven.com"
         content {
             includeGroup "curse.maven"
@@ -189,10 +182,6 @@ dependencies {
 
     //geckolib
     implementation ("com.geckolib:geckolib-neoforge-${minecraft_version}:${geckolib_version}") {transitive=false}
-
-    //smartbrainlib
-    //TODO: use minecraft version variable once sbl is on 26.1
-    implementation ("net.tslat.smartbrainlib:SmartBrainLib-neoforge-1.21.11:${smartbrainlib_version}") {transitive=false}
 
     //TODO: enable once available
     //almostunified
@@ -260,7 +249,6 @@ var generateModMetadata = tasks.register("generateModMetadata", ProcessResources
             theurgy_version        : theurgy_version,
             curios_version         : curios_version,
             geckolib_version       : geckolib_version,
-            smartbrainlib_version  : smartbrainlib_version,
             almost_unified_version : almost_unified_version,
             jei_version            : jei_version,
             emi_version            : emi_version,

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,6 @@ mod_description=A magic mod inspired by the world of Jonathan Stroud's Bartimaeu
 jei_version=19.25.0.322
 curios_version=15.0.0-beta.1
 geckolib_version=5.5
-smartbrainlib_version=1.16.11
 almost_unified_version=0.5.0
 modonomicon_version=1.130.0
 theurgy_version=1.70.0

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/BrainUtil.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/BrainUtil.java
@@ -1,0 +1,64 @@
+package com.klikli_dev.occultism.common.entity.ai;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+public final class BrainUtil {
+
+    private BrainUtil() {
+    }
+
+    public static <U> void clearMemory(Brain<?> brain, MemoryModuleType<U> memoryType) {
+        brain.eraseMemory(memoryType);
+    }
+
+    public static <E extends LivingEntity, U> void clearMemory(E entity, MemoryModuleType<U> memoryType) {
+        clearMemory(entity.getBrain(), memoryType);
+    }
+
+    @Nullable
+    public static <U> U getMemory(Brain<?> brain, MemoryModuleType<U> memoryType) {
+        return brain.getMemory(memoryType).orElse(null);
+    }
+
+    @Nullable
+    public static <E extends LivingEntity, U> U getMemory(E entity, MemoryModuleType<U> memoryType) {
+        return getMemory(entity.getBrain(), memoryType);
+    }
+
+    public static boolean hasMemory(Brain<?> brain, MemoryModuleType<?> memoryType) {
+        return brain.hasMemoryValue(memoryType);
+    }
+
+    public static <E extends LivingEntity> boolean hasMemory(E entity, MemoryModuleType<?> memoryType) {
+        return hasMemory(entity.getBrain(), memoryType);
+    }
+
+    public static <U> U memoryOrDefault(Brain<?> brain, MemoryModuleType<U> memoryType, Supplier<U> defaultSupplier) {
+        return brain.getMemory(memoryType).orElseGet(defaultSupplier);
+    }
+
+    public static <E extends LivingEntity, U> U memoryOrDefault(E entity, MemoryModuleType<U> memoryType, Supplier<U> defaultSupplier) {
+        return memoryOrDefault(entity.getBrain(), memoryType, defaultSupplier);
+    }
+
+    public static <U> void setForgettableMemory(Brain<?> brain, MemoryModuleType<U> memoryType, U value, long expiryTicks) {
+        brain.setMemoryWithExpiry(memoryType, value, expiryTicks);
+    }
+
+    public static <E extends LivingEntity, U> void setForgettableMemory(E entity, MemoryModuleType<U> memoryType, U value, long expiryTicks) {
+        setForgettableMemory(entity.getBrain(), memoryType, value, expiryTicks);
+    }
+
+    public static <U> void setMemory(Brain<?> brain, MemoryModuleType<U> memoryType, @Nullable U value) {
+        brain.setMemory(memoryType, value);
+    }
+
+    public static <E extends LivingEntity, U> void setMemory(E entity, MemoryModuleType<U> memoryType, @Nullable U value) {
+        setMemory(entity.getBrain(), memoryType, value);
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/DepositItemsBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/DepositItemsBehaviour.java
@@ -1,5 +1,6 @@
 package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
 import com.klikli_dev.occultism.util.StorageUtil;
@@ -16,8 +17,6 @@ import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.item.ItemStacksResourceHandler;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.List;
 
@@ -32,11 +31,7 @@ public class DepositItemsBehaviour<E extends SpiritEntity> extends ExtendedBehav
     );
 
     public DepositItemsBehaviour() {
-        super();
-
-        this.runtimeProvider = (entity) -> {
-            return 10;
-        };
+        super(MEMORY_REQUIREMENTS, 10);
     }
 
     protected boolean shouldKeepRunning(E entity) {
@@ -111,10 +106,5 @@ public class DepositItemsBehaviour<E extends SpiritEntity> extends ExtendedBehav
             //event id: opener counter changed, event param: new count
             target.getLevel().blockEvent(target.getBlockPos(), target.getBlockState().getBlock(), 1, 0);
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/ExtendedBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/ExtendedBehaviour.java
@@ -1,0 +1,70 @@
+package com.klikli_dev.occultism.common.entity.ai.behaviour;
+
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.behavior.Behavior;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.MemoryStatus;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class ExtendedBehaviour<E extends LivingEntity> extends Behavior<E> {
+
+    protected ExtendedBehaviour(List<Pair<MemoryModuleType<?>, MemoryStatus>> memoryRequirements) {
+        this(memoryRequirements, 1);
+    }
+
+    protected ExtendedBehaviour(List<Pair<MemoryModuleType<?>, MemoryStatus>> memoryRequirements, int duration) {
+        super(toMemoryMap(memoryRequirements), duration);
+    }
+
+    protected ExtendedBehaviour(List<Pair<MemoryModuleType<?>, MemoryStatus>> memoryRequirements, int minDuration, int maxDuration) {
+        super(toMemoryMap(memoryRequirements), minDuration, maxDuration);
+    }
+
+    private static Map<MemoryModuleType<?>, MemoryStatus> toMemoryMap(List<Pair<MemoryModuleType<?>, MemoryStatus>> memoryRequirements) {
+        Map<MemoryModuleType<?>, MemoryStatus> map = new LinkedHashMap<>();
+
+        for (Pair<MemoryModuleType<?>, MemoryStatus> requirement : memoryRequirements) {
+            map.put(requirement.getFirst(), requirement.getSecond());
+        }
+
+        return Map.copyOf(map);
+    }
+
+    @Override
+    protected final void start(ServerLevel level, E entity, long gameTime) {
+        this.start(entity);
+    }
+
+    protected void start(E entity) {
+    }
+
+    @Override
+    protected final void tick(ServerLevel level, E entity, long gameTime) {
+        this.tick(entity);
+    }
+
+    protected void tick(E entity) {
+    }
+
+    @Override
+    protected final void stop(ServerLevel level, E entity, long gameTime) {
+        this.stop(entity);
+    }
+
+    protected void stop(E entity) {
+    }
+
+    @Override
+    protected final boolean canStillUse(ServerLevel level, E entity, long gameTime) {
+        return this.shouldKeepRunning(entity);
+    }
+
+    protected boolean shouldKeepRunning(E entity) {
+        return false;
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/FellTreeBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/FellTreeBehaviour.java
@@ -1,5 +1,6 @@
 package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestTreeSensor;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
@@ -17,8 +18,6 @@ import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.*;
 
@@ -32,11 +31,7 @@ public class FellTreeBehaviour<E extends SpiritEntity> extends ExtendedBehaviour
     protected int previousBreakProgress;
 
     public FellTreeBehaviour() {
-        super();
-
-        this.runtimeProvider = (entity) -> {
-            return 200;
-        };
+        super(MEMORY_REQUIREMENTS, 200);
     }
 
     @Override
@@ -46,11 +41,6 @@ public class FellTreeBehaviour<E extends SpiritEntity> extends ExtendedBehaviour
         return dist <= FellTreeBehaviour.FELL_TREE_RANGE_SQUARE;
     }
 
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
-    }
 
     protected boolean shouldKeepRunning(E entity) {
         return BrainUtil.hasMemory(entity, OccultismMemoryTypes.NEAREST_TREE.get());
@@ -84,13 +74,13 @@ public class FellTreeBehaviour<E extends SpiritEntity> extends ExtendedBehaviour
                     felled = stump;
                 }
                 BrainUtil.setMemory(entity, OccultismMemoryTypes.LAST_FELLED_TREE.get(), felled);
-                this.stop((ServerLevel) entity.level(), entity, entity.level().getGameTime());
+                this.doStop((ServerLevel) entity.level(), entity, entity.level().getGameTime());
                 //we stop here (even though the above condition would save us) because sensor might reset last felled tree meanwhile
             }
 
         } else {
             //if the tree is gone, just stop and reset.
-            this.stop((ServerLevel) entity.level(), entity, entity.level().getGameTime());
+            this.doStop((ServerLevel) entity.level(), entity, entity.level().getGameTime());
         }
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/FirstApplicableBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/FirstApplicableBehaviour.java
@@ -1,0 +1,40 @@
+package com.klikli_dev.occultism.common.entity.ai.behaviour;
+
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.behavior.BehaviorControl;
+import net.minecraft.world.entity.ai.behavior.GateBehavior;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FirstApplicableBehaviour<E extends LivingEntity> extends GateBehavior<E> {
+
+    @SafeVarargs
+    public FirstApplicableBehaviour(BehaviorControl<? super E>... behaviours) {
+        this(Arrays.asList(behaviours));
+    }
+
+    public FirstApplicableBehaviour(List<? extends BehaviorControl<? super E>> behaviours) {
+        super(
+                Map.of(),
+                Set.of(),
+                OrderPolicy.ORDERED,
+                RunningPolicy.RUN_ONE,
+                weightedBehaviours(behaviours)
+        );
+    }
+
+    private static <E extends LivingEntity> List<Pair<? extends BehaviorControl<? super E>, Integer>> weightedBehaviours(List<? extends BehaviorControl<? super E>> behaviours) {
+        List<Pair<? extends BehaviorControl<? super E>, Integer>> weighted = new ArrayList<>(behaviours.size());
+
+        for (BehaviorControl<? super E> behaviour : behaviours) {
+            weighted.add(Pair.of(behaviour, 1));
+        }
+
+        return weighted;
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/HandleUnreachableCropBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/HandleUnreachableCropBehaviour.java
@@ -2,6 +2,7 @@ package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
@@ -11,8 +12,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.world.entity.ai.behavior.BlockPosTracker;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +25,10 @@ public class HandleUnreachableCropBehaviour<E extends SpiritEntity> extends Exte
             Pair.of(OccultismMemoryTypes.WALK_TARGET_UNREACHABLE.get(), MemoryStatus.VALUE_PRESENT),
             Pair.of(OccultismMemoryTypes.NEAREST_CROP.get(), MemoryStatus.VALUE_PRESENT)
     );
+
+    public HandleUnreachableCropBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected void start(E entity) {
@@ -45,10 +48,5 @@ public class HandleUnreachableCropBehaviour<E extends SpiritEntity> extends Exte
                 }
             }
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/HandleUnreachableTreeBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/HandleUnreachableTreeBehaviour.java
@@ -2,6 +2,7 @@ package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
@@ -11,8 +12,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.world.entity.ai.behavior.BlockPosTracker;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +25,10 @@ public class HandleUnreachableTreeBehaviour<E extends SpiritEntity> extends Exte
             Pair.of(OccultismMemoryTypes.WALK_TARGET_UNREACHABLE.get(), MemoryStatus.VALUE_PRESENT),
             Pair.of(OccultismMemoryTypes.NEAREST_TREE.get(), MemoryStatus.VALUE_PRESENT)
     );
+
+    public HandleUnreachableTreeBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected void start(E entity) {
@@ -45,10 +48,5 @@ public class HandleUnreachableTreeBehaviour<E extends SpiritEntity> extends Exte
                 }
             }
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/HarvestCropBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/HarvestCropBehaviour.java
@@ -1,5 +1,6 @@
 package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestCropSensor;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
@@ -14,8 +15,6 @@ import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -27,9 +26,7 @@ public class HarvestCropBehaviour<E extends SpiritEntity> extends ExtendedBehavi
             Pair.of(OccultismMemoryTypes.NEAREST_CROP.get(), MemoryStatus.VALUE_PRESENT));
 
     public HarvestCropBehaviour() {
-        super();
-
-        this.runtimeProvider = (entity) -> 20;
+        super(MEMORY_REQUIREMENTS, 20);
     }
 
     @Override
@@ -39,11 +36,6 @@ public class HarvestCropBehaviour<E extends SpiritEntity> extends ExtendedBehavi
         return dist <= HarvestCropBehaviour.HARVEST_CROP_RANGE_SQUARE;
     }
 
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
-    }
 
     protected boolean shouldKeepRunning(E entity) {
         return BrainUtil.hasMemory(entity, OccultismMemoryTypes.NEAREST_CROP.get());
@@ -68,11 +60,11 @@ public class HarvestCropBehaviour<E extends SpiritEntity> extends ExtendedBehavi
                     }
                 }
             }
-            this.stop((ServerLevel) entity.level(), entity, entity.level().getGameTime());
+            this.doStop((ServerLevel) entity.level(), entity, entity.level().getGameTime());
             //we stop here (even though the above condition would save us) because sensor might reset last harvested crop meanwhile
         } else {
             //if the crop is gone, just stop and reset.
-            this.stop((ServerLevel) entity.level(), entity, entity.level().getGameTime());
+            this.doStop((ServerLevel) entity.level(), entity, entity.level().getGameTime());
         }
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/PickupItemBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/PickupItemBehaviour.java
@@ -1,5 +1,6 @@
 package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
 import com.klikli_dev.occultism.util.Math3DUtil;
@@ -13,8 +14,6 @@ import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import com.klikli_dev.occultism.util.ItemTransferUtil;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -28,6 +27,10 @@ public class PickupItemBehaviour<E extends SpiritEntity> extends ExtendedBehavio
             Pair.of(OccultismMemoryTypes.DEPOSIT_POSITION.get(), MemoryStatus.VALUE_PRESENT), //we only pick up, if we can deposit
             Pair.of(OccultismMemoryTypes.DEPOSIT_FACING.get(), MemoryStatus.VALUE_PRESENT)
     );
+
+    public PickupItemBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected boolean checkExtraStartConditions(@NotNull ServerLevel level, @NotNull E entity) {
@@ -60,10 +63,5 @@ public class PickupItemBehaviour<E extends SpiritEntity> extends ExtendedBehavio
         }
 
         BrainUtil.clearMemory(entity, MemoryModuleType.NEAREST_VISIBLE_WANTED_ITEM);
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/ReplantSaplingBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/ReplantSaplingBehaviour.java
@@ -1,9 +1,9 @@
 package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
 import com.klikli_dev.occultism.util.ItemTransferUtil;
-import com.klikli_dev.occultism.util.StorageUtil;
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.server.level.ServerLevel;
@@ -17,8 +17,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.List;
 
@@ -28,6 +26,10 @@ public class ReplantSaplingBehaviour<E extends SpiritEntity> extends ExtendedBeh
     private static final List<Pair<MemoryModuleType<?>, MemoryStatus>> MEMORY_REQUIREMENTS = ObjectArrayList.of(
             Pair.of(OccultismMemoryTypes.LAST_FELLED_TREE.get(), MemoryStatus.VALUE_PRESENT)
     );
+
+    public ReplantSaplingBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected boolean checkExtraStartConditions(ServerLevel level, E entity) {
@@ -66,10 +68,5 @@ public class ReplantSaplingBehaviour<E extends SpiritEntity> extends ExtendedBeh
         } else {
             BrainUtil.setMemory(entity, OccultismMemoryTypes.LAST_FELLED_TREE.get(), lastFelledTreeList);
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToCropBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToCropBehaviour.java
@@ -2,6 +2,7 @@ package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
@@ -15,8 +16,6 @@ import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.entity.ai.memory.WalkTarget;
 import net.minecraft.world.phys.Vec3;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +35,10 @@ public class SetWalkTargetToCropBehaviour<E extends SpiritEntity> extends Extend
             Pair.of(OccultismMemoryTypes.UNREACHABLE_CROPS.get(), MemoryStatus.REGISTERED),
             Pair.of(OccultismMemoryTypes.UNREACHABLE_WALK_TARGETS.get(), MemoryStatus.REGISTERED)
     );
+
+    public SetWalkTargetToCropBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected void start(E entity) {
@@ -80,10 +83,5 @@ public class SetWalkTargetToCropBehaviour<E extends SpiritEntity> extends Extend
                 }
             }
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToDepositBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToDepositBehaviour.java
@@ -2,12 +2,12 @@ package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
 import com.klikli_dev.occultism.util.ItemTransferUtil;
-import com.klikli_dev.occultism.util.StorageUtil;
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
@@ -18,8 +18,6 @@ import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.entity.ai.memory.WalkTarget;
 import net.minecraft.world.phys.Vec3;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -35,6 +33,10 @@ public class SetWalkTargetToDepositBehaviour<E extends SpiritEntity> extends Ext
             Pair.of(OccultismMemoryTypes.DEPOSIT_POSITION.get(), MemoryStatus.VALUE_PRESENT),
             Pair.of(OccultismMemoryTypes.DEPOSIT_FACING.get(), MemoryStatus.VALUE_PRESENT)
     );
+
+    public SetWalkTargetToDepositBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected boolean checkExtraStartConditions(ServerLevel level, E entity) {
@@ -80,10 +82,5 @@ public class SetWalkTargetToDepositBehaviour<E extends SpiritEntity> extends Ext
                 }
             }
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToItemBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToItemBehaviour.java
@@ -2,6 +2,7 @@ package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
@@ -13,8 +14,6 @@ import net.minecraft.world.entity.ai.behavior.EntityTracker;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.entity.ai.memory.WalkTarget;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.List;
 
@@ -30,6 +29,10 @@ public class SetWalkTargetToItemBehaviour<E extends SpiritEntity> extends Extend
             Pair.of(OccultismMemoryTypes.DEPOSIT_POSITION.get(), MemoryStatus.VALUE_PRESENT), //we only pick up, if we can deposit
             Pair.of(OccultismMemoryTypes.DEPOSIT_FACING.get(), MemoryStatus.VALUE_PRESENT)
     );
+
+    public SetWalkTargetToItemBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected void start(E entity) {
@@ -51,10 +54,5 @@ public class SetWalkTargetToItemBehaviour<E extends SpiritEntity> extends Extend
         } else {
             BrainUtil.clearMemory(entity, MemoryModuleType.NEAREST_VISIBLE_WANTED_ITEM);
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToReplantSaplingBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToReplantSaplingBehaviour.java
@@ -2,12 +2,12 @@ package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
 import com.klikli_dev.occultism.util.ItemTransferUtil;
-import com.klikli_dev.occultism.util.StorageUtil;
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.server.level.ServerLevel;
@@ -17,8 +17,6 @@ import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.entity.ai.memory.WalkTarget;
 import net.minecraft.world.phys.Vec3;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.List;
 
@@ -32,6 +30,10 @@ public class SetWalkTargetToReplantSaplingBehaviour<E extends SpiritEntity> exte
             Pair.of(MemoryModuleType.LOOK_TARGET, MemoryStatus.REGISTERED),
             Pair.of(OccultismMemoryTypes.LAST_FELLED_TREE.get(), MemoryStatus.VALUE_PRESENT)
     );
+
+    public SetWalkTargetToReplantSaplingBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected boolean checkExtraStartConditions(ServerLevel level, E entity) {
@@ -51,10 +53,5 @@ public class SetWalkTargetToReplantSaplingBehaviour<E extends SpiritEntity> exte
                 Networking.sendToTracking(entity, new MessageSelectBlock(treePos, 5000, OccultismConstants.Color.GREEN));
             }
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToTreeBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/SetWalkTargetToTreeBehaviour.java
@@ -2,6 +2,7 @@ package com.klikli_dev.occultism.common.entity.ai.behaviour;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
@@ -15,8 +16,6 @@ import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.minecraft.world.entity.ai.memory.WalkTarget;
 import net.minecraft.world.phys.Vec3;
-import net.tslat.smartbrainlib.api.core.behaviour.ExtendedBehaviour;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +35,10 @@ public class SetWalkTargetToTreeBehaviour<E extends SpiritEntity> extends Extend
             Pair.of(OccultismMemoryTypes.UNREACHABLE_TREES.get(), MemoryStatus.REGISTERED),
             Pair.of(OccultismMemoryTypes.UNREACHABLE_WALK_TARGETS.get(), MemoryStatus.REGISTERED)
     );
+
+    public SetWalkTargetToTreeBehaviour() {
+        super(MEMORY_REQUIREMENTS);
+    }
 
     @Override
     protected void start(E entity) {
@@ -80,10 +83,5 @@ public class SetWalkTargetToTreeBehaviour<E extends SpiritEntity> extends Extend
                 }
             }
         }
-    }
-
-    @Override
-    protected List<Pair<MemoryModuleType<?>, MemoryStatus>> getMemoryRequirements() {
-        return MEMORY_REQUIREMENTS;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/ExtendedSensor.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/ExtendedSensor.java
@@ -1,0 +1,26 @@
+package com.klikli_dev.occultism.common.entity.ai.sensor;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+
+import java.util.List;
+import java.util.Set;
+
+public abstract class ExtendedSensor<E extends LivingEntity> extends Sensor<E> {
+
+    protected ExtendedSensor() {
+        super();
+    }
+
+    protected ExtendedSensor(int scanRate) {
+        super(scanRate);
+    }
+
+    public abstract List<MemoryModuleType<?>> memoriesUsed();
+
+    @Override
+    public Set<MemoryModuleType<?>> requires() {
+        return Set.copyOf(this.memoriesUsed());
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/NearestCropSensor.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/NearestCropSensor.java
@@ -2,23 +2,20 @@ package com.klikli_dev.occultism.common.entity.ai.sensor;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.ai.BlockSorter;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
-import com.klikli_dev.occultism.registry.OccultismSensors;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
-import net.minecraft.world.entity.ai.sensing.SensorType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.FarmlandBlock;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
@@ -34,11 +31,15 @@ public class NearestCropSensor<E extends SpiritEntity> extends ExtendedSensor<E>
     public static final int RESCAN_EMPTY_WORK_AREA_AFTER_TICKS = 20 * 20;
     private static final List<MemoryModuleType<?>> MEMORIES = ObjectArrayList.of(
             OccultismMemoryTypes.NEAREST_CROP.get(),
-            OccultismMemoryTypes.NON_CROP.get()
+            OccultismMemoryTypes.NON_CROP.get(),
+            OccultismMemoryTypes.NO_CROP_IN_WORK_AREA.get(),
+            OccultismMemoryTypes.UNREACHABLE_CROPS.get(),
+            OccultismMemoryTypes.WORK_AREA_CENTER.get(),
+            OccultismMemoryTypes.WORK_AREA_SIZE.get()
     );
 
     public NearestCropSensor() {
-        this.setScanRate((entity) -> DEFAULT_SCAN_RATE_TICKS);
+        super(DEFAULT_SCAN_RATE_TICKS);
     }
 
     public static boolean isCropSoil(Level level, BlockPos pos) {
@@ -53,11 +54,6 @@ public class NearestCropSensor<E extends SpiritEntity> extends ExtendedSensor<E>
     @Override
     public List<MemoryModuleType<?>> memoriesUsed() {
         return MEMORIES;
-    }
-
-    @Override
-    public SensorType<? extends ExtendedSensor<?>> type() {
-        return OccultismSensors.NEAREST_CROP.get();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/NearestJobItemSensor.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/NearestJobItemSensor.java
@@ -2,42 +2,40 @@ package com.klikli_dev.occultism.common.entity.ai.sensor;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
-import com.klikli_dev.occultism.registry.OccultismSensors;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
-import net.minecraft.world.entity.ai.sensing.SensorType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.phys.AABB;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.api.core.sensor.PredicateSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
-import net.tslat.smartbrainlib.util.EntityRetrievalUtil;
 
+import java.util.Comparator;
+import java.util.function.BiPredicate;
 import java.util.List;
 
-public class NearestJobItemSensor<E extends SpiritEntity> extends PredicateSensor<ItemEntity, E> {
+public class NearestJobItemSensor<E extends SpiritEntity> extends ExtendedSensor<E> {
     public static final int DEFAULT_SCAN_RATE_TICKS = 20;
-    private static final List<MemoryModuleType<?>> MEMORIES = ObjectArrayList.of(MemoryModuleType.NEAREST_VISIBLE_WANTED_ITEM);
+    private static final List<MemoryModuleType<?>> MEMORIES = ObjectArrayList.of(
+            MemoryModuleType.NEAREST_VISIBLE_WANTED_ITEM,
+            OccultismMemoryTypes.WORK_AREA_CENTER.get(),
+            OccultismMemoryTypes.WORK_AREA_SIZE.get()
+    );
+    private final BiPredicate<ItemEntity, E> predicate;
 
     public NearestJobItemSensor() {
-        super((item, entity) -> {
-            return entity.canPickupItem(item) && entity.hasLineOfSight(item);
-        });
+        super(DEFAULT_SCAN_RATE_TICKS);
 
-        this.setScanRate((entity) -> DEFAULT_SCAN_RATE_TICKS);
+        this.predicate = (item, entity) -> {
+            return entity.canPickupItem(item) && entity.hasLineOfSight(item);
+        };
     }
 
     public List<MemoryModuleType<?>> memoriesUsed() {
         return MEMORIES;
-    }
-
-    public SensorType<? extends ExtendedSensor<?>> type() {
-        return OccultismSensors.NEAREST_JOB_ITEM.get();
     }
 
     protected void doTick(ServerLevel level, E entity) {
@@ -54,6 +52,11 @@ public class NearestJobItemSensor<E extends SpiritEntity> extends PredicateSenso
         var workAreaCenter = BrainUtil.getMemory(entity, OccultismMemoryTypes.WORK_AREA_CENTER.get());
         var workAreaSize = BrainUtil.getMemory(entity, OccultismMemoryTypes.WORK_AREA_SIZE.get());
 
+        if (workAreaCenter == null || workAreaSize == null) {
+            BrainUtil.clearMemory(entity, MemoryModuleType.NEAREST_VISIBLE_WANTED_ITEM);
+            return;
+        }
+
         if (Occultism.DEBUG.debugAI) {
             Networking.sendToTracking(entity, new MessageSelectBlock(workAreaCenter, 5000, OccultismConstants.Color.BLUE));
             Networking.sendToTracking(entity, new MessageSelectBlock(workAreaCenter.offset(workAreaSize / 2, workAreaSize / 2, workAreaSize / 2), 5000, OccultismConstants.Color.CYAN));
@@ -69,13 +72,10 @@ public class NearestJobItemSensor<E extends SpiritEntity> extends PredicateSenso
         var aabb = new AABB(workAreaCenter.getCenter().add(-workAreaSize / 2f, -workAreaSize / 2f, -workAreaSize / 2f),
                 workAreaCenter.getCenter().add(workAreaSize / 2f, workAreaSize / 2f, workAreaSize / 2f));
 
-        ItemEntity nearestEntity = (ItemEntity) EntityRetrievalUtil.getNearestEntity(level,
-                aabb, entity.position(), (obj) -> {
-                    if (obj instanceof ItemEntity item) {
-                        return this.predicate().test(item, entity);
-                    }
-                    return false;
-                }).orElse(null);
+        ItemEntity nearestEntity = level.getEntitiesOfClass(ItemEntity.class, aabb, item -> this.predicate.test(item, entity))
+                .stream()
+                .min(Comparator.comparingDouble(entity::distanceToSqr))
+                .orElse(null);
 
         BrainUtil.setMemory(entity, MemoryModuleType.NEAREST_VISIBLE_WANTED_ITEM, nearestEntity);
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/NearestJobItemSensor.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/NearestJobItemSensor.java
@@ -13,7 +13,6 @@ import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.phys.AABB;
 
-import java.util.Comparator;
 import java.util.function.BiPredicate;
 import java.util.List;
 
@@ -72,10 +71,17 @@ public class NearestJobItemSensor<E extends SpiritEntity> extends ExtendedSensor
         var aabb = new AABB(workAreaCenter.getCenter().add(-workAreaSize / 2f, -workAreaSize / 2f, -workAreaSize / 2f),
                 workAreaCenter.getCenter().add(workAreaSize / 2f, workAreaSize / 2f, workAreaSize / 2f));
 
-        ItemEntity nearestEntity = level.getEntitiesOfClass(ItemEntity.class, aabb, item -> this.predicate.test(item, entity))
-                .stream()
-                .min(Comparator.comparingDouble(entity::distanceToSqr))
-                .orElse(null);
+        ItemEntity nearestEntity = null;
+        double nearestDistance = Double.MAX_VALUE;
+
+        for (ItemEntity item : level.getEntitiesOfClass(ItemEntity.class, aabb, candidate -> this.predicate.test(candidate, entity))) {
+            double candidateDistance = entity.distanceToSqr(item);
+
+            if (candidateDistance < nearestDistance) {
+                nearestDistance = candidateDistance;
+                nearestEntity = item;
+            }
+        }
 
         BrainUtil.setMemory(entity, MemoryModuleType.NEAREST_VISIBLE_WANTED_ITEM, nearestEntity);
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/NearestTreeSensor.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/NearestTreeSensor.java
@@ -2,12 +2,12 @@ package com.klikli_dev.occultism.common.entity.ai.sensor;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.ai.BlockSorter;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
-import com.klikli_dev.occultism.registry.OccultismSensors;
 import com.klikli_dev.occultism.registry.OccultismTags;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
@@ -15,11 +15,8 @@ import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
-import net.minecraft.world.entity.ai.sensing.SensorType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.LeavesBlock;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
@@ -35,11 +32,15 @@ public class NearestTreeSensor<E extends SpiritEntity> extends ExtendedSensor<E>
     public static final int RESCAN_EMPTY_WORK_AREA_AFTER_TICKS = 20 * 30;
     private static final List<MemoryModuleType<?>> MEMORIES = ObjectArrayList.of(
             OccultismMemoryTypes.NEAREST_TREE.get(),
-            OccultismMemoryTypes.NON_TREE_LOGS.get()
+            OccultismMemoryTypes.NON_TREE_LOGS.get(),
+            OccultismMemoryTypes.NO_TREE_IN_WORK_AREA.get(),
+            OccultismMemoryTypes.UNREACHABLE_TREES.get(),
+            OccultismMemoryTypes.WORK_AREA_CENTER.get(),
+            OccultismMemoryTypes.WORK_AREA_SIZE.get()
     );
 
     public NearestTreeSensor() {
-        this.setScanRate((entity) -> DEFAULT_SCAN_RATE_TICKS);
+        super(DEFAULT_SCAN_RATE_TICKS);
     }
 
     public static boolean isTreeSoil(Level level, BlockPos pos) {
@@ -58,11 +59,6 @@ public class NearestTreeSensor<E extends SpiritEntity> extends ExtendedSensor<E>
     @Override
     public List<MemoryModuleType<?>> memoriesUsed() {
         return MEMORIES;
-    }
-
-    @Override
-    public SensorType<? extends ExtendedSensor<?>> type() {
-        return OccultismSensors.NEAREST_TREE.get();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/UnreachableCropWalkTargetSensor.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/UnreachableCropWalkTargetSensor.java
@@ -2,18 +2,15 @@ package com.klikli_dev.occultism.common.entity.ai.sensor;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
-import com.klikli_dev.occultism.registry.OccultismSensors;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
-import net.minecraft.world.entity.ai.sensing.SensorType;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.List;
 
@@ -30,10 +27,6 @@ public class UnreachableCropWalkTargetSensor<E extends LivingEntity> extends Ext
 
     public List<MemoryModuleType<?>> memoriesUsed() {
         return MEMORIES;
-    }
-
-    public SensorType<? extends ExtendedSensor<?>> type() {
-        return OccultismSensors.UNREACHABLE_WALK_TARGET.get();
     }
 
     protected void doTick(ServerLevel level, E entity) {

--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/UnreachableTreeWalkTargetSensor.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/sensor/UnreachableTreeWalkTargetSensor.java
@@ -2,18 +2,15 @@ package com.klikli_dev.occultism.common.entity.ai.sensor;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.OccultismConstants;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.network.Networking;
 import com.klikli_dev.occultism.network.messages.MessageSelectBlock;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
-import com.klikli_dev.occultism.registry.OccultismSensors;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
-import net.minecraft.world.entity.ai.sensing.SensorType;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.List;
 
@@ -30,10 +27,6 @@ public class UnreachableTreeWalkTargetSensor<E extends LivingEntity> extends Ext
 
     public List<MemoryModuleType<?>> memoriesUsed() {
         return MEMORIES;
-    }
-
-    public SensorType<? extends ExtendedSensor<?>> type() {
-        return OccultismSensors.UNREACHABLE_WALK_TARGET.get();
     }
 
     protected void doTick(ServerLevel level, E entity) {

--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/FarmerJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/FarmerJob.java
@@ -24,22 +24,24 @@ package com.klikli_dev.occultism.common.entity.job;
 
 import com.google.common.collect.ImmutableList;
 import com.klikli_dev.occultism.common.entity.ai.behaviour.*;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestCropSensor;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestJobItemSensor;
 import com.klikli_dev.occultism.common.entity.ai.sensor.UnreachableCropWalkTargetSensor;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
+import com.klikli_dev.occultism.registry.OccultismSensors;
+import net.minecraft.world.entity.ai.ActivityData;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.behavior.LookAtTargetSink;
+import net.minecraft.world.entity.ai.behavior.MoveToTargetSink;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.ai.sensing.SensorType;
+import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.common.Tags;
-import net.tslat.smartbrainlib.api.core.BrainActivityGroup;
-import net.tslat.smartbrainlib.api.core.behaviour.FirstApplicableBehaviour;
-import net.tslat.smartbrainlib.api.core.behaviour.custom.move.MoveToWalkTarget;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,48 +55,43 @@ public class FarmerJob extends SpiritJob {
     }
 
     @Override
-    public List<ExtendedSensor<SpiritEntity>> getSensors() {
+    @SuppressWarnings("unchecked")
+    public List<SensorType<? extends Sensor<SpiritEntity>>> getSensorTypes() {
         return ImmutableList.of(
-                new NearestCropSensor<>(),
-                new NearestJobItemSensor<>(),
-                new UnreachableCropWalkTargetSensor<>()
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.NEAREST_CROP.get(),
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.NEAREST_JOB_ITEM.get(),
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.UNREACHABLE_CROP_WALK_TARGET.get()
         );
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public BrainActivityGroup<SpiritEntity> getCoreTasks() {
-        //TODO: when idle we probably should walk to center of work area
-
-        //priority is handled by the set target behaviours mostly
-        //replant, deposit, pickup and fell tree should be gated by distance to tree/item/block/lastfelledtree anyway
-        //TODO: check if that works, or if we need firstApplicable or something here too -> for close quarters work
-
-        return BrainActivityGroup.coreTasks(
-                new LookAtTargetSink(8, 8),
-                new FirstApplicableBehaviour<>(
-                    new MoveToWalkTarget<>(),
-                    new HarvestCropBehaviour<>(),
-                    new PickupItemBehaviour<>(),
-                    new DepositItemsBehaviour<>()
-                )
-        );
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public BrainActivityGroup<SpiritEntity> getIdleTasks() {
-
-        //prefer replanting saplings over depositing
-        //prefer depositing over picking up job items
-        //prefer job items to pick up, over trees
-        return BrainActivityGroup.idleTasks(
-                new FirstApplicableBehaviour<>(
-                        new SetWalkTargetToCropBehaviour<>(),
-                        new SetWalkTargetToDepositBehaviour<>(),
-                        new SetWalkTargetToItemBehaviour<>()
+    public List<ActivityData<SpiritEntity>> getActivityData() {
+        return List.of(
+                ActivityData.create(
+                        Activity.CORE,
+                        0,
+                        ImmutableList.of(
+                                new LookAtTargetSink(8, 8),
+                                new FirstApplicableBehaviour<>(
+                                        new MoveToTargetSink(),
+                                        new HarvestCropBehaviour<>(),
+                                        new PickupItemBehaviour<>(),
+                                        new DepositItemsBehaviour<>()
+                                )
+                        )
                 ),
-                new HandleUnreachableCropBehaviour<>()
+                ActivityData.create(
+                        Activity.IDLE,
+                        0,
+                        ImmutableList.of(
+                                new FirstApplicableBehaviour<>(
+                                        new SetWalkTargetToCropBehaviour<>(),
+                                        new SetWalkTargetToDepositBehaviour<>(),
+                                        new SetWalkTargetToItemBehaviour<>()
+                                ),
+                                new HandleUnreachableCropBehaviour<>()
+                        )
+                )
         );
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/LumberjackJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/LumberjackJob.java
@@ -24,24 +24,26 @@ package com.klikli_dev.occultism.common.entity.job;
 
 import com.google.common.collect.ImmutableList;
 import com.klikli_dev.occultism.common.entity.ai.behaviour.*;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestJobItemSensor;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestTreeSensor;
 import com.klikli_dev.occultism.common.entity.ai.sensor.UnreachableTreeWalkTargetSensor;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
+import com.klikli_dev.occultism.registry.OccultismSensors;
 import com.klikli_dev.occultism.registry.OccultismTags;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.world.entity.ai.ActivityData;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.behavior.LookAtTargetSink;
+import net.minecraft.world.entity.ai.behavior.MoveToTargetSink;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.ai.sensing.SensorType;
+import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
-import net.tslat.smartbrainlib.api.core.BrainActivityGroup;
-import net.tslat.smartbrainlib.api.core.behaviour.FirstApplicableBehaviour;
-import net.tslat.smartbrainlib.api.core.behaviour.custom.move.MoveToWalkTarget;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,50 +57,45 @@ public class LumberjackJob extends SpiritJob {
     }
 
     @Override
-    public List<ExtendedSensor<SpiritEntity>> getSensors() {
+    @SuppressWarnings("unchecked")
+    public List<SensorType<? extends Sensor<SpiritEntity>>> getSensorTypes() {
         return ImmutableList.of(
-                new NearestTreeSensor<>(),
-                new NearestJobItemSensor<>(),
-                new UnreachableTreeWalkTargetSensor<>()
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.NEAREST_TREE.get(),
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.NEAREST_JOB_ITEM.get(),
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.UNREACHABLE_TREE_WALK_TARGET.get()
         );
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public BrainActivityGroup<SpiritEntity> getCoreTasks() {
-        //TODO: when idle we probably should walk to center of work area
-
-        //priority is handled by the set target behaviours mostly
-        //replant, deposit, pickup and fell tree should be gated by distance to tree/item/block/lastfelledtree anyway
-        //TODO: check if that works, or if we need firstApplicable or something here too -> for close quarters work
-
-        return BrainActivityGroup.coreTasks(
-                new LookAtTargetSink(8, 8),
-                new FirstApplicableBehaviour<>(
-                        new MoveToWalkTarget<>(),
-                        new ReplantSaplingBehaviour<>(),
-                        new DepositItemsBehaviour<>(),
-                        new PickupItemBehaviour<>(),
-                        new FellTreeBehaviour<>()
-                )
-        );
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public BrainActivityGroup<SpiritEntity> getIdleTasks() {
-
-        //prefer replanting saplings over depositing
-        //prefer depositing over picking up job items
-        //prefer job items to pick up, over trees
-        return BrainActivityGroup.idleTasks(
-                new FirstApplicableBehaviour<>(
-                        new SetWalkTargetToReplantSaplingBehaviour<>(),
-                        new SetWalkTargetToDepositBehaviour<>(),
-                        new SetWalkTargetToItemBehaviour<>(),
-                        new SetWalkTargetToTreeBehaviour<>()
+    public List<ActivityData<SpiritEntity>> getActivityData() {
+        return List.of(
+                ActivityData.create(
+                        Activity.CORE,
+                        0,
+                        ImmutableList.of(
+                                new LookAtTargetSink(8, 8),
+                                new FirstApplicableBehaviour<>(
+                                        new MoveToTargetSink(),
+                                        new ReplantSaplingBehaviour<>(),
+                                        new DepositItemsBehaviour<>(),
+                                        new PickupItemBehaviour<>(),
+                                        new FellTreeBehaviour<>()
+                                )
+                        )
                 ),
-                new HandleUnreachableTreeBehaviour<>()
+                ActivityData.create(
+                        Activity.IDLE,
+                        0,
+                        ImmutableList.of(
+                                new FirstApplicableBehaviour<>(
+                                        new SetWalkTargetToReplantSaplingBehaviour<>(),
+                                        new SetWalkTargetToDepositBehaviour<>(),
+                                        new SetWalkTargetToItemBehaviour<>(),
+                                        new SetWalkTargetToTreeBehaviour<>()
+                                ),
+                                new HandleUnreachableTreeBehaviour<>()
+                        )
+                )
         );
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/SpiritJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/SpiritJob.java
@@ -23,20 +23,22 @@
 package com.klikli_dev.occultism.common.entity.job;
 
 import com.google.common.collect.ImmutableList;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
 import com.klikli_dev.occultism.registry.OccultismSpiritJobs;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.ai.ActivityData;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.ai.sensing.SensorType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.crafting.Ingredient;
-import net.tslat.smartbrainlib.api.core.BrainActivityGroup;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
 
 import java.util.List;
 
@@ -69,7 +71,6 @@ public abstract class SpiritJob {
      * Sets up the job, e.g. AI Tasks
      */
     public final void init() {
-        this.entity.remakeBrain();
         BrainUtil.setMemory(this.entity, OccultismMemoryTypes.WORK_AREA_CENTER.get(), this.entity.getWorkAreaCenter());
         BrainUtil.setMemory(this.entity, OccultismMemoryTypes.WORK_AREA_SIZE.get(), this.entity.getWorkAreaSize().getValue());
         BrainUtil.setMemory(this.entity, OccultismMemoryTypes.DEPOSIT_POSITION.get(), this.entity.getDepositPosition().orElse(null));
@@ -79,16 +80,16 @@ public abstract class SpiritJob {
 
     protected abstract void onInit();
 
-    public List<ExtendedSensor<SpiritEntity>> getSensors() {
+    public List<MemoryModuleType<?>> getMemoryTypes() {
+        return OccultismMemoryTypes.all();
+    }
+
+    public List<SensorType<? extends Sensor<SpiritEntity>>> getSensorTypes() {
         return ImmutableList.of();
     }
 
-    public BrainActivityGroup<SpiritEntity> getCoreTasks() {
-        return BrainActivityGroup.empty();
-    }
-
-    public BrainActivityGroup<SpiritEntity> getIdleTasks() {
-        return BrainActivityGroup.empty();
+    public List<ActivityData<SpiritEntity>> getActivityData() {
+        return ImmutableList.of();
     }
 
     public void handleAdditionalBrainSetup(Brain<? extends SpiritEntity> brain) {

--- a/src/main/java/com/klikli_dev/occultism/common/entity/spirit/SpiritEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/spirit/SpiritEntity.java
@@ -23,6 +23,7 @@
 package com.klikli_dev.occultism.common.entity.spirit;
 
 import com.google.common.collect.ImmutableList;
+import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.api.common.data.WorkAreaSize;
 import com.klikli_dev.occultism.common.container.spirit.SpiritContainer;
 import com.klikli_dev.occultism.common.entity.job.SpiritJob;
@@ -67,12 +68,6 @@ import net.minecraft.world.level.storage.ValueOutput;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.item.ItemStacksResourceHandler;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
-import net.tslat.smartbrainlib.api.SmartBrainOwner;
-import net.tslat.smartbrainlib.api.core.BrainActivityGroup;
-import net.tslat.smartbrainlib.api.core.SmartBrain;
-import net.tslat.smartbrainlib.api.core.SmartBrainProvider;
-import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
-import net.tslat.smartbrainlib.util.BrainUtil;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -80,7 +75,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCreatureMixin, MenuProvider, SmartBrainOwner<SpiritEntity> {
+public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCreatureMixin, MenuProvider {
     public static final EntityDataAccessor<Integer> SKIN = SynchedEntityData
             .defineId(SpiritEntity.class, EntityDataSerializers.INT);
     /**
@@ -174,33 +169,25 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
 
     @Override
     protected Brain<?> makeBrain(Brain.Packed packedBrain) {
-        return new SmartBrainProvider<>(this, true).makeBrain(this, packedBrain);
+        if (this.getJob().isEmpty()) {
+            return new Brain<>();
+        }
+
+        SpiritJob job = this.getJob().get();
+        Brain<SpiritEntity> brain = Brain.provider(job.getMemoryTypes(), job.getSensorTypes(), entity -> job.getActivityData())
+                .makeBrain(this, packedBrain);
+        job.handleAdditionalBrainSetup(brain);
+        return brain;
     }
 
     @Override
     protected void customServerAiStep(ServerLevel level) {
-        this.tickBrain(this);
+        this.getBrain().tick(level, this);
     }
 
     @Override
-    public void handleAdditionalBrainSetup(SmartBrain<? extends SpiritEntity> brain) {
-        //we might want to init brain vars that come from spirit vars here, but as this happens before entity is in the world, we are missing fallback data such as entity position that some of our spirit vars (work area center) use
-        this.getJob().ifPresent(job -> job.handleAdditionalBrainSetup(brain));
-    }
-
-    @Override
-    public List<ExtendedSensor<SpiritEntity>> getSensors() {
-        return this.getJob().isPresent() ? this.getJob().get().getSensors() : ImmutableList.of();
-    }
-
-    @Override
-    public BrainActivityGroup<SpiritEntity> getCoreTasks() {
-        return this.getJob().isPresent() ? this.getJob().get().getCoreTasks() : BrainActivityGroup.empty();
-    }
-
-    @Override
-    public BrainActivityGroup<SpiritEntity> getIdleTasks() {
-        return this.getJob().isPresent() ? this.getJob().get().getIdleTasks() : BrainActivityGroup.empty();
+    public Brain<SpiritEntity> getBrain() {
+        return (Brain<SpiritEntity>) super.getBrain();
     }
 
     @Override
@@ -417,6 +404,11 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
             if (recreateBrain) {
                 this.remakeBrain();
             }
+        } else {
+            this.setJobID("");
+            if (recreateBrain) {
+                this.remakeBrain();
+            }
         }
     }
 
@@ -613,12 +605,9 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
         //read job
         input.read("spiritJob", CompoundTag.CODEC).ifPresent(tag -> {
             SpiritJob job = SpiritJob.from(this, tag);
-            // Check if brain data exists (we can't use contains with 2 args in 26.1)
-            var hasBrain = input.read("Brain", CompoundTag.CODEC).isPresent();
-            this.setJob(job, !hasBrain);
-            if (hasBrain) {
-                this.brain = this.makeBrain(Brain.Packed.EMPTY);
-            }
+            Brain.Packed packedBrain = input.read("Brain", Brain.Packed.CODEC).orElse(Brain.Packed.EMPTY);
+            this.setJob(job, false);
+            this.brain = this.makeBrain(packedBrain);
         });
 
         this.setFilterBlacklist(input.getBooleanOr("isFilterBlacklist", this.isFilterBlacklist()));

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismMemoryTypes.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismMemoryTypes.java
@@ -42,4 +42,26 @@ public class OccultismMemoryTypes {
     public static final Supplier<MemoryModuleType<BlockPos>> DEPOSIT_POSITION = MEMORY_MODULE_TYPES.register("deposit_position", () -> new MemoryModuleType<>(Optional.empty()));
 
     public static final Supplier<MemoryModuleType<Direction>> DEPOSIT_FACING = MEMORY_MODULE_TYPES.register("deposit_facing", () -> new MemoryModuleType<>(Optional.empty()));
+
+    public static List<MemoryModuleType<?>> all() {
+        return List.of(
+                NEAREST_TREE.get(),
+                LAST_FELLED_TREE.get(),
+                LAST_TREE_WALK_TARGET.get(),
+                NO_TREE_IN_WORK_AREA.get(),
+                NON_TREE_LOGS.get(),
+                NEAREST_CROP.get(),
+                LAST_CROP_WALK_TARGET.get(),
+                NO_CROP_IN_WORK_AREA.get(),
+                NON_CROP.get(),
+                WORK_AREA_CENTER.get(),
+                WORK_AREA_SIZE.get(),
+                WALK_TARGET_UNREACHABLE.get(),
+                UNREACHABLE_WALK_TARGETS.get(),
+                UNREACHABLE_TREES.get(),
+                UNREACHABLE_CROPS.get(),
+                DEPOSIT_POSITION.get(),
+                DEPOSIT_FACING.get()
+        );
+    }
 }

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismSensors.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismSensors.java
@@ -26,6 +26,7 @@ import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestCropSensor;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestJobItemSensor;
 import com.klikli_dev.occultism.common.entity.ai.sensor.NearestTreeSensor;
+import com.klikli_dev.occultism.common.entity.ai.sensor.UnreachableCropWalkTargetSensor;
 import com.klikli_dev.occultism.common.entity.ai.sensor.UnreachableTreeWalkTargetSensor;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.ai.sensing.SensorType;
@@ -41,8 +42,11 @@ public class OccultismSensors {
     public static final Supplier<SensorType<NearestCropSensor<?>>> NEAREST_CROP = SENSORS.register("nearest_crop",
             () -> new SensorType<>(NearestCropSensor::new));
 
-    public static final Supplier<SensorType<UnreachableTreeWalkTargetSensor<?>>> UNREACHABLE_WALK_TARGET = SENSORS.register("unreachable_walk_target",
+    public static final Supplier<SensorType<UnreachableTreeWalkTargetSensor<?>>> UNREACHABLE_TREE_WALK_TARGET = SENSORS.register("unreachable_walk_target",
             () -> new SensorType<>(UnreachableTreeWalkTargetSensor::new));
+
+    public static final Supplier<SensorType<UnreachableCropWalkTargetSensor<?>>> UNREACHABLE_CROP_WALK_TARGET = SENSORS.register("unreachable_crop_walk_target",
+            () -> new SensorType<>(UnreachableCropWalkTargetSensor::new));
 
     public static final Supplier<SensorType<NearestJobItemSensor<?>>> NEAREST_JOB_ITEM = SENSORS.register("nearest_job_item",
             () -> new SensorType<>(NearestJobItemSensor::new));

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -61,12 +61,6 @@ versionRange = "[${geckolib_version},)"
 side = "BOTH"
 
 [[dependencies.${mod_id}]]
-modId = "smartbrainlib"
-type = "required"
-versionRange = "[${smartbrainlib_version},)"
-side = "BOTH"
-
-[[dependencies.${mod_id}]]
 modId = "almostunified"
 type = "optional"
 versionRange = "[${almost_unified_version},)"


### PR DESCRIPTION
## Summary
- replace the lumberjack and farmer spirit SmartBrainLib integration with vanilla brain activities, sensors, and behavior adapters
- preserve spirit AI memory handling and brain rebuild/load semantics while removing the SmartBrainLib dependency from runtime code paths
- remove SmartBrainLib from build, mod metadata, workflow dependency metadata, and the obsolete version property