### PR TITLE
fix: align satchel hotkey with selected stack (#1528)

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/container/satchel/AbstractSatchelContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/satchel/AbstractSatchelContainer.java
@@ -38,6 +38,9 @@ import javax.annotation.Nullable;
 
 public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
 
+    public static final int CURIO_SLOT = -1;
+    public static final int OFFHAND_SLOT = -2;
+
     protected Container satchelInventory;
     protected Inventory playerInventory;
     protected int selectedSlot;
@@ -51,11 +54,7 @@ public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
         this.selectedSlot = selectedSlot;
         this.satchelUuid = satchelUuid;
 
-        if (this.selectedSlot == -1) {
-            this.satchelStack = CuriosUtil.getBackpack(playerInventory.player);
-        } else {
-            this.satchelStack = playerInventory.player.getInventory().getItem(this.selectedSlot).copy();
-        }
+        this.satchelStack = this.getTrackedSatchelStack(playerInventory.player).copy();
 
 
         this.setupSatchelSlots();
@@ -109,12 +108,7 @@ public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
-        ItemStack stack = ItemStack.EMPTY;
-        if (this.selectedSlot == -1) {
-            stack = CuriosUtil.getBackpack(player);
-        } else if (this.selectedSlot >= 0 && this.selectedSlot < player.getInventory().getContainerSize()) {
-            stack = player.getInventory().getItem(this.selectedSlot);
-        }
+        ItemStack stack = this.getTrackedSatchelStack(player);
 
         if (stack.isEmpty() || stack.getItem() != this.satchelStack.getItem())
             return false;
@@ -144,6 +138,22 @@ public abstract class AbstractSatchelContainer extends AbstractContainerMenu {
         for (int i = 0; i < 9; i++) {
             this.addSlot(new Slot(this.playerInventory, i, hotbarLeft + i * 18, hotbarTop));
         }
+    }
+
+    protected ItemStack getTrackedSatchelStack(Player player) {
+        if (this.selectedSlot == CURIO_SLOT) {
+            return CuriosUtil.getBackpack(player);
+        }
+
+        if (this.selectedSlot == OFFHAND_SLOT) {
+            return player.getOffhandItem();
+        }
+
+        if (this.selectedSlot >= 0 && this.selectedSlot < player.getInventory().getContainerSize()) {
+            return player.getInventory().getItem(this.selectedSlot);
+        }
+
+        return ItemStack.EMPTY;
     }
 
     protected abstract void setupSatchelSlots();

--- a/src/main/java/com/klikli_dev/occultism/common/item/storage/SatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/storage/SatchelItem.java
@@ -49,8 +49,7 @@ public class SatchelItem extends Item {
         final ItemStack stack = player.getItemInHand(hand);
 
         if (!level.isClientSide && player instanceof ServerPlayer serverPlayer) {
-            //here we use main hand item as selected slot
-            int selectedSlot = hand == InteractionHand.MAIN_HAND ? player.getInventory().selected : -1;
+            int selectedSlot = hand == InteractionHand.MAIN_HAND ? player.getInventory().selected : StorageSatchelContainer.OFFHAND_SLOT;
 
             if (!stack.has(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID)) {
                 stack.set(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID, java.util.UUID.randomUUID());

--- a/src/main/java/com/klikli_dev/occultism/handlers/ClientPlayerEventHandler.java
+++ b/src/main/java/com/klikli_dev/occultism/handlers/ClientPlayerEventHandler.java
@@ -98,7 +98,8 @@ public class ClientPlayerEventHandler {
     public static void checkBackpackKey() {
         Minecraft minecraft = Minecraft.getInstance();
         if (minecraft.player != null & minecraft.screen == null && ClientSetupEventHandler.KEY_BACKPACK.consumeClick()
-                && (!CuriosUtil.getBackpack(minecraft.player).isEmpty() || CuriosUtil.getFirstBackpackSlot(minecraft.player) >= 0)) {
+                && (minecraft.player.getOffhandItem().getItem() instanceof com.klikli_dev.occultism.common.item.storage.SatchelItem
+                || !CuriosUtil.getBackpack(minecraft.player).isEmpty() || CuriosUtil.getFirstBackpackSlot(minecraft.player) >= 0)) {
             Networking.sendToServer(new MessageOpenSatchel());
             minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.ARMOR_EQUIP_LEATHER.value(), 0.75F, 1.0F));
         }

--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
@@ -55,16 +55,22 @@ public class MessageOpenSatchel implements IMessage {
     @Override
     public void onServerReceived(MinecraftServer minecraftServer, ServerPlayer player) {
 
-        int selectedSlot = -1;
-        //first attempt to get backpack from curios slot
-        ItemStack backpackStack = CuriosUtil.getBackpack(player);
+        int selectedSlot = player.getInventory().selected;
+        ItemStack backpackStack = player.getInventory().getSelected();
 
-        //if not found, try to get from player inventory
+        // first attempt to get backpack from the currently selected stack to match right-click behavior
+        if (!(backpackStack.getItem() instanceof SatchelItem)) {
+            selectedSlot = -1;
+            backpackStack = CuriosUtil.getBackpack(player);
+        }
+
+        // if not found, try to get from player inventory
         if (!(backpackStack.getItem() instanceof SatchelItem)) {
             selectedSlot = CuriosUtil.getFirstBackpackSlot(player);
             backpackStack = selectedSlot >= 0 ? player.getInventory().getItem(selectedSlot) : ItemStack.EMPTY;
         }
-        //now, if we have a satchel, proceed
+
+        // now, if we have a satchel, proceed
         if (backpackStack.getItem() instanceof SatchelItem) {
             if (!backpackStack.has(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID)) {
                 backpackStack.set(com.klikli_dev.occultism.registry.OccultismDataComponents.SATCHEL_UUID, UUID.randomUUID());

--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageOpenSatchel.java
@@ -58,9 +58,14 @@ public class MessageOpenSatchel implements IMessage {
         int selectedSlot = player.getInventory().selected;
         ItemStack backpackStack = player.getInventory().getSelected();
 
-        // first attempt to get backpack from the currently selected stack to match right-click behavior
+        // first attempt to get backpack from the held stacks to match right-click behavior
         if (!(backpackStack.getItem() instanceof SatchelItem)) {
-            selectedSlot = -1;
+            selectedSlot = StorageSatchelContainer.OFFHAND_SLOT;
+            backpackStack = player.getOffhandItem();
+        }
+
+        if (!(backpackStack.getItem() instanceof SatchelItem)) {
+            selectedSlot = StorageSatchelContainer.CURIO_SLOT;
             backpackStack = CuriosUtil.getBackpack(player);
         }
 


### PR DESCRIPTION
## Summary
- make the satchel hotkey prefer the currently selected satchel before falling back to Curios or the first inventory satchel
- align hotkey opening with right-click behavior so both paths open the same physical satchel stack
- keep the UUID-based container validation from #1523 intact

Closes #1528