### PR TITLE
Backport Greedy Familiar filtering UI to version/26.1

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/client/gui/spirit/SpiritGui.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/spirit/SpiritGui.java
@@ -25,6 +25,7 @@ package com.klikli_dev.occultism.client.gui.spirit;
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.client.gui.controls.LabelWidget;
 import com.klikli_dev.occultism.common.container.spirit.SpiritContainer;
+import com.klikli_dev.occultism.common.entity.IFilterConfigurable;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.util.TextUtil;
 import net.minecraft.ChatFormatting;
@@ -45,7 +46,7 @@ public class SpiritGui<T extends SpiritContainer> extends AbstractContainerScree
     protected static final Identifier TEXTURE = Identifier.fromNamespaceAndPath(Occultism.MODID,
             "textures/gui/inventory_spirit.png");
     protected static final String TRANSLATION_KEY_BASE = "gui." + Occultism.MODID + ".spirit";
-    protected SpiritEntity spirit;
+    protected IFilterConfigurable spirit;
     protected T container;
 
     public SpiritGui(T container, Inventory playerInventory, Component titleIn) {
@@ -78,17 +79,17 @@ public class SpiritGui<T extends SpiritContainer> extends AbstractContainerScree
 
         int labelHeight = 9;
         LabelWidget nameLabel = new LabelWidget(this.leftPos + 65, this.topPos + 17, false, -1, 2, 0x404040);
-        nameLabel.addLine(TextUtil.formatDemonName(this.spirit.getName().getString()));
+        nameLabel.addLine(TextUtil.formatDemonName(this.spirit.getEntity().getName().getString()));
         this.addRenderableWidget(nameLabel);
 
-        if (this.spirit.getSpiritMaxAge() >= 0) {
-            int agePercent = (int) Math.floor(this.spirit.getSpiritAge() / (float) this.spirit.getSpiritMaxAge() * 100);
+        if (this.spirit instanceof SpiritEntity spiritEntity && spiritEntity.getSpiritMaxAge() >= 0) {
+            int agePercent = (int) Math.floor(spiritEntity.getSpiritAge() / (float) spiritEntity.getSpiritMaxAge() * 100);
             LabelWidget ageLabel = new LabelWidget(this.leftPos + 65, this.topPos + 17 + labelHeight + 5, false, -1, 2, 0x404040);
             ageLabel.addLine(I18n.get(TRANSLATION_KEY_BASE + ".age", agePercent));
             this.addRenderableWidget(ageLabel);
         }
 
-        String jobID = this.spirit.getJobID();
+        String jobID = this.spirit instanceof SpiritEntity spiritEntity ? spiritEntity.getJobID() : "";
         if (!StringUtils.isBlank(jobID)) {
             jobID = jobID.replace(":", ".");
             LabelWidget jobLabel = new LabelWidget(this.leftPos + 65,
@@ -117,7 +118,7 @@ public class SpiritGui<T extends SpiritContainer> extends AbstractContainerScree
         guiGraphics.pose().pushMatrix();
         int scale = 30;
         drawEntityToGui(guiGraphics, this.leftPos + 35, this.topPos + 65, scale, this.leftPos + 51 - x,
-                this.topPos + 75 - 50 - y, this.spirit);
+                this.topPos + 75 - 50 - y, this.spirit.getEntity());
         guiGraphics.pose().popMatrix();
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/client/gui/spirit/SpiritTransporterGui.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/spirit/SpiritTransporterGui.java
@@ -82,7 +82,7 @@ public class SpiritTransporterGui extends SpiritGui<SpiritTransporterContainer> 
 
     public void setIsBlacklist(boolean isBlacklist) {
         this.spirit.setFilterBlacklist(isBlacklist);
-        Networking.sendToServer(new MessageSetFilterMode(isBlacklist, this.spirit.getId()));
+        Networking.sendToServer(new MessageSetFilterMode(isBlacklist, this.spirit.getEntity().getId()));
     }
     //endregion Getter / Setter
 
@@ -135,7 +135,7 @@ public class SpiritTransporterGui extends SpiritGui<SpiritTransporterContainer> 
         guiGraphics.pose().pushMatrix();
         int scale = 30;
         drawEntityToGui(guiGraphics, this.leftPos + 35, this.topPos + 65, scale, this.leftPos + 51 - x,
-                this.topPos + 75 - 50 - y, this.spirit);
+                this.topPos + 75 - 50 - y, this.spirit.getEntity());
         guiGraphics.pose().popMatrix();
     }
 
@@ -211,7 +211,7 @@ public class SpiritTransporterGui extends SpiritGui<SpiritTransporterContainer> 
 
         //we used to check for blank tag filter here, but that prevents emptying the filter
         this.spirit.setTagFilter(this.tagFilter);
-        Networking.sendToServer(new MessageSetTagFilterText(this.tagFilter, this.spirit.getId()));
+        Networking.sendToServer(new MessageSetTagFilterText(this.tagFilter, this.spirit.getEntity().getId()));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/container/spirit/SpiritContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/spirit/SpiritContainer.java
@@ -22,6 +22,7 @@
 
 package com.klikli_dev.occultism.common.container.spirit;
 
+import com.klikli_dev.occultism.common.entity.IFilterConfigurable;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismContainers;
 import net.minecraft.world.entity.player.Inventory;
@@ -38,15 +39,15 @@ import javax.annotation.Nullable;
 public class SpiritContainer extends AbstractContainerMenu {
 
     public ItemStacksResourceHandler inventory;
-    public SpiritEntity spirit;
+    public IFilterConfigurable spirit;
 
     public SpiritContainer(int id, Inventory playerInventory, SpiritEntity spirit) {
         this(OccultismContainers.SPIRIT.get(), id, playerInventory, spirit);
     }
 
-    public SpiritContainer(@Nullable MenuType<?> type, int id, Inventory playerInventory, SpiritEntity spirit) {
+    public SpiritContainer(@Nullable MenuType<?> type, int id, Inventory playerInventory, IFilterConfigurable spirit) {
         super(type, id);
-        this.inventory = spirit.inventory;
+        this.inventory = spirit.getInventory();
         this.spirit = spirit;
 
         this.setupSlots(playerInventory);
@@ -87,7 +88,7 @@ public class SpiritContainer extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player entityPlayer) {
-        return this.spirit.isAlive() && this.spirit.distanceTo(entityPlayer) < 8.0F;
+        return this.spirit.getEntity().isAlive() && this.spirit.getEntity().distanceTo(entityPlayer) < 8.0F;
     }
 
     public void setupSlots(Inventory playerInventory) {
@@ -117,8 +118,13 @@ public class SpiritContainer extends AbstractContainerMenu {
         this.addSlot(new ResourceHandlerSlot(this.inventory, this.inventory::set, 0, 152, 54) {
 
             @Override
+            public boolean isActive() {
+                return SpiritContainer.this.spirit.isInventorySlotActive();
+            }
+
+            @Override
             public boolean mayPlace(ItemStack stack) {
-                return super.mayPlace(stack);
+                return SpiritContainer.this.spirit.canPlaceInInventory(stack) && super.mayPlace(stack);
             }
 
         });

--- a/src/main/java/com/klikli_dev/occultism/common/container/spirit/SpiritTransporterContainer.java
+++ b/src/main/java/com/klikli_dev/occultism/common/container/spirit/SpiritTransporterContainer.java
@@ -22,6 +22,7 @@
 
 package com.klikli_dev.occultism.common.container.spirit;
 
+import com.klikli_dev.occultism.common.entity.IFilterConfigurable;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import com.klikli_dev.occultism.registry.OccultismContainers;
 import net.minecraft.world.entity.player.Inventory;
@@ -36,10 +37,17 @@ import javax.annotation.Nonnull;
 
 public class SpiritTransporterContainer extends SpiritContainer {
 
+    public static final int FILTER_SIZE = 14;
+
     protected final Player player;
 
     public SpiritTransporterContainer(int id, Inventory playerInventory,
                                       SpiritEntity spirit) {
+        this(id, playerInventory, (IFilterConfigurable) spirit);
+    }
+
+    public SpiritTransporterContainer(int id, Inventory playerInventory,
+                                      IFilterConfigurable spirit) {
 
         super(OccultismContainers.SPIRIT_TRANSPORTER.get(), id, playerInventory, spirit);
 
@@ -99,7 +107,7 @@ public class SpiritTransporterContainer extends SpiritContainer {
     protected void setupFilterSlots() {
         int x = 8;
         int y = 84;
-        ItemStacksResourceHandler filterItems = this.spirit.filterItemStackHandler;
+        ItemStacksResourceHandler filterItems = this.spirit.getFilterItems();
 
         for (int i = 0; i < 2; i++) {
             for (int j = 0; j < filterItems.size() / 2; j++) {
@@ -113,7 +121,7 @@ public class SpiritTransporterContainer extends SpiritContainer {
     public ItemStack quickMoveStack(Player playerIn, int index) {
         ItemStack itemstack = ItemStack.EMPTY;
         Slot slot = this.slots.get(index);
-        final int filterSize = 14; // CHANGE IF FILTER SIZE IS CHANGED
+        final int filterSize = FILTER_SIZE;
 
         if (slot != null && slot.hasItem()) {
             ItemStack itemstack1 = slot.getItem();

--- a/src/main/java/com/klikli_dev/occultism/common/entity/IFilterConfigurable.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/IFilterConfigurable.java
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright 2020 klikli-dev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.klikli_dev.occultism.common.entity;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.transfer.item.ItemStacksResourceHandler;
+
+public interface IFilterConfigurable {
+
+    boolean isFilterBlacklist();
+
+    void setFilterBlacklist(boolean isFilterBlacklist);
+
+    String getTagFilter();
+
+    void setTagFilter(String tagFilter);
+
+    ItemStacksResourceHandler getFilterItems();
+
+    ItemStacksResourceHandler getInventory();
+
+    LivingEntity getEntity();
+
+    default boolean canPlaceInInventory(ItemStack stack) {
+        return true;
+    }
+
+    default boolean isInventorySlotActive() {
+        return true;
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/GreedyFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/GreedyFamiliarEntity.java
@@ -25,39 +25,79 @@ package com.klikli_dev.occultism.common.entity.familiar;
 import com.google.common.collect.ImmutableList;
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.common.advancement.FamiliarTrigger;
+import com.klikli_dev.occultism.common.container.spirit.SpiritTransporterContainer;
+import com.klikli_dev.occultism.common.entity.IFilterConfigurable;
 import com.klikli_dev.occultism.registry.OccultismAdvancements;
 import com.klikli_dev.occultism.registry.OccultismEntities;
 import com.klikli_dev.occultism.util.ItemTransferUtil;
+import com.klikli_dev.occultism.util.StorageUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.MenuProvider;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.goal.*;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.level.storage.TagValueInput;
+import net.minecraft.world.level.storage.TagValueOutput;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import net.minecraft.util.ProblemReporter;
+import net.neoforged.neoforge.transfer.item.ItemResource;
+import net.neoforged.neoforge.transfer.item.ItemStacksResourceHandler;
 import net.neoforged.neoforge.transfer.item.PlayerInventoryWrapper;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
 
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
-public class GreedyFamiliarEntity extends FamiliarEntity {
+public class GreedyFamiliarEntity extends FamiliarEntity implements IFilterConfigurable, MenuProvider {
 
     private static final EntityDataAccessor<Optional<BlockPos>> TARGET_BLOCK = SynchedEntityData
             .defineId(GreedyFamiliarEntity.class, EntityDataSerializers.OPTIONAL_BLOCK_POS);
+    private static final EntityDataAccessor<Boolean> IS_FILTER_BLACKLIST = SynchedEntityData
+            .defineId(GreedyFamiliarEntity.class, EntityDataSerializers.BOOLEAN);
+    private static final EntityDataAccessor<String> FILTER_ITEMS = SynchedEntityData
+            .defineId(GreedyFamiliarEntity.class, EntityDataSerializers.STRING);
+    private static final EntityDataAccessor<String> TAG_FILTER = SynchedEntityData
+            .defineId(GreedyFamiliarEntity.class, EntityDataSerializers.STRING);
+
+    public ItemStacksResourceHandler inventory = new ItemStacksResourceHandler(1) {
+        @Override
+        protected void onContentsChanged(int slot, ItemStack previousContents) {
+            super.onContentsChanged(slot, previousContents);
+            GreedyFamiliarEntity.this.setItemInHand(InteractionHand.OFF_HAND, this.getResource(0).toStack());
+        }
+    };
+
+    public ItemStacksResourceHandler filterItemStackHandler = new ItemStacksResourceHandler(SpiritTransporterContainer.FILTER_SIZE) {
+        @Override
+        protected void onContentsChanged(int slot, ItemStack previousContents) {
+            super.onContentsChanged(slot, previousContents);
+            TagValueOutput tagOutput = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, GreedyFamiliarEntity.this.level().registryAccess());
+            this.serialize(tagOutput);
+            GreedyFamiliarEntity.this.entityData.set(FILTER_ITEMS, tagOutput.buildResult().toString());
+        }
+    };
 
     private float earRotZ, earRotZ0, earRotX, earRotX0, peekRot, peekRot0, monsterRot, monsterRot0;
     private int monsterAnimTimer;
@@ -85,6 +125,71 @@ public class GreedyFamiliarEntity extends FamiliarEntity {
     protected void defineSynchedData(SynchedEntityData.Builder builder) {
         super.defineSynchedData(builder);
         builder.define(TARGET_BLOCK, Optional.empty());
+        builder.define(IS_FILTER_BLACKLIST, true);
+        builder.define(FILTER_ITEMS, "");
+        builder.define(TAG_FILTER, "");
+    }
+
+    @Override
+    public void onSyncedDataUpdated(EntityDataAccessor<?> key) {
+        super.onSyncedDataUpdated(key);
+
+        if (key == FILTER_ITEMS && this.level().isClientSide()) {
+            String compoundStr = this.entityData.get(FILTER_ITEMS);
+            if (!compoundStr.isEmpty()) {
+                try {
+                    var compound = net.minecraft.nbt.TagParser.parseCompoundFully(compoundStr);
+                    ValueInput valueInput = TagValueInput.create(ProblemReporter.DISCARDING, this.level().registryAccess(), compound);
+                    this.filterItemStackHandler.deserialize(valueInput);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean isFilterBlacklist() {
+        return this.entityData.get(IS_FILTER_BLACKLIST);
+    }
+
+    @Override
+    public void setFilterBlacklist(boolean isFilterBlacklist) {
+        this.entityData.set(IS_FILTER_BLACKLIST, isFilterBlacklist);
+    }
+
+    @Override
+    public String getTagFilter() {
+        return this.entityData.get(TAG_FILTER);
+    }
+
+    @Override
+    public void setTagFilter(String tagFilter) {
+        this.entityData.set(TAG_FILTER, tagFilter);
+    }
+
+    @Override
+    public ItemStacksResourceHandler getFilterItems() {
+        return this.filterItemStackHandler;
+    }
+
+    @Override
+    public ItemStacksResourceHandler getInventory() {
+        return this.inventory;
+    }
+
+    @Override
+    public LivingEntity getEntity() {
+        return this;
+    }
+
+    @Override
+    public boolean canPlaceInInventory(ItemStack stack) {
+        return this.hasBlacksmithUpgrade() && stack.getItem() instanceof BlockItem;
+    }
+
+    @Override
+    public boolean isInventorySlotActive() {
+        return this.hasBlacksmithUpgrade();
     }
 
     public Optional<BlockPos> getTargetBlock() {
@@ -112,10 +217,19 @@ public class GreedyFamiliarEntity extends FamiliarEntity {
                 boolean isStackDemagnetized = false;//TODO: Find what the updated convention is for stack.hasTag() && stack.getTag().getBoolean("PreventRemoteMovement");
                 boolean isEntityDemagnetized = e.getPersistentData().getBoolean("PreventRemoteMovement").orElse(false);
 
-                if (!isStackDemagnetized && !isEntityDemagnetized) {
+                if (!isStackDemagnetized && !isEntityDemagnetized && this.canPickupItem(e)) {
                     e.playerTouch((Player) wearer);
                 }
             }
+    }
+
+    public boolean canPickupItem(ItemEntity entity) {
+        ItemStack stack = entity.getItem();
+        boolean matches = StorageUtil.matchesFilter(stack, this.getFilterItems()) ||
+                StorageUtil.matchesFilter(stack, this.getTagFilter());
+
+        boolean isBlacklist = this.isFilterBlacklist();
+        return ((!isBlacklist && matches) || (isBlacklist && !matches));
     }
 
     @Override
@@ -196,17 +310,83 @@ public class GreedyFamiliarEntity extends FamiliarEntity {
     @Override
     protected InteractionResult mobInteract(Player playerIn, InteractionHand hand) {
         ItemStack stack = playerIn.getItemInHand(hand);
+        if (playerIn.isShiftKeyDown() && this.getFamiliarOwner() == playerIn) {
+            this.openScreen(playerIn);
+            return this.level().isClientSide() ? InteractionResult.SUCCESS : InteractionResult.SUCCESS_SERVER;
+        }
+
         if (this.hasBlacksmithUpgrade() && !this.getOffhandItem().isEmpty()) {
             ItemTransferUtil.giveItemToPlayer(playerIn, this.getOffhandItem());
-            this.setItemInHand(InteractionHand.OFF_HAND, ItemStack.EMPTY);
+            try (var tx = Transaction.openRoot()) {
+                this.inventory.extract(0, this.inventory.getResource(0), 1, tx);
+                tx.commit();
+            }
             return this.level().isClientSide() ? InteractionResult.SUCCESS : InteractionResult.SUCCESS_SERVER;
         } else if (this.hasBlacksmithUpgrade() && stack.getItem() instanceof BlockItem) {
-            this.setItemInHand(InteractionHand.OFF_HAND, new ItemStack(stack.getItem()));
+            try (var tx = Transaction.openRoot()) {
+                this.inventory.set(0, ItemResource.of(new ItemStack(stack.getItem())), 1);
+                tx.commit();
+            }
             stack.shrink(1);
             return this.level().isClientSide() ? InteractionResult.SUCCESS : InteractionResult.SUCCESS_SERVER;
         }
 
         return super.mobInteract(playerIn, hand);
+    }
+
+    public void openScreen(Player playerEntity) {
+        if (!this.level().isClientSide() && playerEntity instanceof ServerPlayer serverPlayer) {
+            serverPlayer.openMenu(this, buf -> buf.writeInt(this.getId()));
+        }
+    }
+
+    @Override
+    public Component getDisplayName() {
+        return super.getDisplayName();
+    }
+
+    @Override
+    public AbstractContainerMenu createMenu(int id, Inventory playerInventory, Player player) {
+        return new SpiritTransporterContainer(id, playerInventory, this);
+    }
+
+    @Override
+    public void readAdditionalSaveData(ValueInput input) {
+        super.readAdditionalSaveData(input);
+
+        input.read("inventory", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(tag -> {
+            ValueInput inventoryInput = TagValueInput.create(ProblemReporter.DISCARDING, this.level().registryAccess(), tag);
+            this.inventory.deserialize(inventoryInput);
+        });
+
+        this.setFilterBlacklist(input.getBooleanOr("isFilterBlacklist", true));
+
+        input.read("filterItems", net.minecraft.nbt.CompoundTag.CODEC).ifPresent(tag -> {
+            tag.putInt("Size", SpiritTransporterContainer.FILTER_SIZE);
+            ValueInput filterInput = TagValueInput.create(ProblemReporter.DISCARDING, this.level().registryAccess(), tag);
+            this.filterItemStackHandler.deserialize(filterInput);
+        });
+
+        input.getString("tagFilter").ifPresent(this::setTagFilter);
+    }
+
+    @Override
+    public void addAdditionalSaveData(ValueOutput output) {
+        super.addAdditionalSaveData(output);
+
+        {
+            TagValueOutput inv = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, this.level().registryAccess());
+            this.inventory.serialize(inv);
+            output.store("inventory", net.minecraft.nbt.CompoundTag.CODEC, inv.buildResult());
+        }
+
+        output.putBoolean("isFilterBlacklist", this.isFilterBlacklist());
+        {
+            TagValueOutput filterOut = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, this.level().registryAccess());
+            this.filterItemStackHandler.serialize(filterOut);
+            output.store("filterItems", net.minecraft.nbt.CompoundTag.CODEC, filterOut.buildResult());
+        }
+        output.putString("tagFilter", this.getTagFilter());
     }
 
 
@@ -261,6 +441,7 @@ public class GreedyFamiliarEntity extends FamiliarEntity {
                 boolean isEntityDemagnetized = item.getPersistentData().getBoolean("PreventRemoteMovement").orElse(false);
 
                 if ((!isStackDemagnetized && !isEntityDemagnetized)
+                        && this.entity instanceof GreedyFamiliarEntity greedy && greedy.canPickupItem(item)
                         && com.klikli_dev.occultism.util.ItemTransferUtil.insertItemStacked(inv, stack, true).getCount() != stack.getCount())
                     return item;
             }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/spirit/SpiritEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/spirit/SpiritEntity.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.klikli_dev.occultism.common.entity.ai.BrainUtil;
 import com.klikli_dev.occultism.api.common.data.WorkAreaSize;
 import com.klikli_dev.occultism.common.container.spirit.SpiritContainer;
+import com.klikli_dev.occultism.common.entity.IFilterConfigurable;
 import com.klikli_dev.occultism.common.entity.job.SpiritJob;
 import com.klikli_dev.occultism.common.item.spirit.BookOfCallingItem;
 import com.klikli_dev.occultism.registry.OccultismMemoryTypes;
@@ -75,7 +76,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCreatureMixin, MenuProvider {
+public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCreatureMixin, MenuProvider, IFilterConfigurable {
     public static final EntityDataAccessor<Integer> SKIN = SynchedEntityData
             .defineId(SpiritEntity.class, EntityDataSerializers.INT);
     /**
@@ -337,6 +338,7 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
     /**
      * @return the filter mode
      */
+    @Override
     public boolean isFilterBlacklist() {
         return this.entityData.get(IS_FILTER_BLACKLIST);
     }
@@ -346,6 +348,7 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
      *
      * @param isFilterBlacklist the filter mode
      */
+    @Override
     public void setFilterBlacklist(boolean isFilterBlacklist) {
         this.entityData.set(IS_FILTER_BLACKLIST, isFilterBlacklist);
     }
@@ -353,6 +356,7 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
     /**
      * Gets the tag filter string
      */
+    @Override
     public String getTagFilter() {
         return this.entityData.get(TAG_FILTER);
     }
@@ -360,6 +364,7 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
     /**
      * Sets the tag filter string
      */
+    @Override
     public void setTagFilter(String tagFilter) {
         this.entityData.set(TAG_FILTER, tagFilter);
     }
@@ -367,8 +372,14 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
     /**
      * @return the filter mode
      */
+    @Override
     public ItemStacksResourceHandler getFilterItems() {
         return this.filterItemStackHandler;
+    }
+
+    @Override
+    public ItemStacksResourceHandler getInventory() {
+        return this.inventory;
     }
 
     public Optional<SpiritJob> getJob() {

--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageSetFilterMode.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageSetFilterMode.java
@@ -23,7 +23,7 @@
 package com.klikli_dev.occultism.network.messages;
 
 import com.klikli_dev.occultism.Occultism;
-import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
+import com.klikli_dev.occultism.common.entity.IFilterConfigurable;
 import com.klikli_dev.occultism.network.IMessage;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -55,8 +55,8 @@ public class MessageSetFilterMode implements IMessage {
     public void onServerReceived(MinecraftServer minecraftServer, ServerPlayer player) {
 
         Entity e = player.level().getEntity(this.entityId);
-        if (e instanceof SpiritEntity spirit) {
-            spirit.setFilterBlacklist(this.isBlacklistFilter);
+        if (e instanceof IFilterConfigurable filterConfigurable) {
+            filterConfigurable.setFilterBlacklist(this.isBlacklistFilter);
         }
     }
 

--- a/src/main/java/com/klikli_dev/occultism/network/messages/MessageSetTagFilterText.java
+++ b/src/main/java/com/klikli_dev/occultism/network/messages/MessageSetTagFilterText.java
@@ -23,7 +23,7 @@
 package com.klikli_dev.occultism.network.messages;
 
 import com.klikli_dev.occultism.Occultism;
-import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
+import com.klikli_dev.occultism.common.entity.IFilterConfigurable;
 import com.klikli_dev.occultism.network.IMessage;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -55,8 +55,8 @@ public class MessageSetTagFilterText implements IMessage {
     public void onServerReceived(MinecraftServer minecraftServer, ServerPlayer player) {
 
         Entity e = player.level().getEntity(this.entityId);
-        if (e instanceof SpiritEntity spirit) {
-            spirit.setTagFilter(this.tagFilterText);
+        if (e instanceof IFilterConfigurable filterConfigurable) {
+            filterConfigurable.setTagFilter(this.tagFilterText);
         }
     }
 

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismContainers.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismContainers.java
@@ -38,6 +38,7 @@ import com.klikli_dev.occultism.common.container.spirit.SpiritTransporterContain
 import com.klikli_dev.occultism.common.container.storage.StableWormholeContainer;
 import com.klikli_dev.occultism.common.container.storage.StorageControllerContainer;
 import com.klikli_dev.occultism.common.container.storage.StorageRemoteContainer;
+import com.klikli_dev.occultism.common.entity.IFilterConfigurable;
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.inventory.MenuType;
@@ -83,7 +84,7 @@ public class OccultismContainers {
                     () -> IMenuTypeExtension
                             .create((windowId, inv, data) -> {
                                 return new SpiritTransporterContainer(windowId, inv,
-                                        (SpiritEntity) inv.player.level().getEntity(data.readInt()));
+                                        (IFilterConfigurable) inv.player.level().getEntity(data.readInt()));
                             }));
 
     public static final Supplier<MenuType<DimensionalMineshaftContainer>> OTHERWORLD_MINER =


### PR DESCRIPTION
## Summary
- backport the Greedy Familiar filtering UI and pickup filtering logic from #1526 to ersion/26.1
- share spirit filter GUI/container/message handling through IFilterConfigurable so the familiar can reuse the transporter filter screen
- preserve existing Greedy Familiar behavior by defaulting to blacklist mode and keeping the blacksmith offhand slot gated behind the upgrade

## Validation
- ./gradlew.bat compileJava

## Related
- Backport of #1526