### PR TITLE
Fix familiar AI stopping when riding other familiars

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/CthulhuFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/CthulhuFamiliarEntity.java
@@ -44,9 +44,7 @@ import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.control.MoveControl;
-import net.minecraft.world.entity.ai.goal.Goal;
-import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
-import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
+import net.minecraft.world.entity.ai.goal.*;
 import net.minecraft.world.entity.ai.navigation.GroundPathNavigation;
 import net.minecraft.world.entity.ai.navigation.WaterBoundPathNavigation;
 import net.minecraft.world.entity.ai.util.DefaultRandomPos;
@@ -97,6 +95,7 @@ public class CthulhuFamiliarEntity extends FamiliarEntity {
         this.goalSelector.addGoal(3, new FollowOwnerWaterGoal(this, 1, 3, 1));
         this.goalSelector.addGoal(4, new GiveFlowerGoal(this));
         this.goalSelector.addGoal(5, new RandomStrollGoal(this, 1.0D));
+        this.goalSelector.addGoal(6, new FollowMobGoal(this, 1, 3, 7));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/FamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/FamiliarEntity.java
@@ -58,6 +58,7 @@ import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
 import net.neoforged.neoforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.UUID;
@@ -231,6 +232,12 @@ public abstract class FamiliarEntity extends PathfinderMob implements IFamiliar 
     @Override
     public Entity getFamiliarEntity() {
         return this;
+    }
+
+    @Nullable
+    @Override
+    public LivingEntity getControllingPassenger() {
+        return null;
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/GreedyFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/GreedyFamiliarEntity.java
@@ -413,6 +413,9 @@ public class GreedyFamiliarEntity extends FamiliarEntity implements IFilterConfi
                 return null;
 
             IItemHandler inv = new PlayerMainInvWrapper(player.getInventory());
+            GreedyFamiliarEntity greedy = this.getGreedyFamiliar();
+            if (greedy == null)
+                return null;
 
             for (ItemEntity item : this.entity.level().getEntitiesOfClass(ItemEntity.class,
                     this.entity.getBoundingBox().inflate(RANGE), e -> e.isAlive())) {
@@ -421,17 +424,22 @@ public class GreedyFamiliarEntity extends FamiliarEntity implements IFilterConfi
                 boolean isStackDemagnetized = false;//TODO: Find what the updated convention is for stack.hasTag() && stack.getTag().getBoolean("PreventRemoteMovement");
                 boolean isEntityDemagnetized = item.getPersistentData().getBoolean("PreventRemoteMovement");
 
-                GreedyFamiliarEntity greedy = null;
-                if (this.entity instanceof GreedyFamiliarEntity g) {
-                    greedy = g;
-                } else if (this.entity.getFirstPassenger() instanceof GreedyFamiliarEntity g) {
-                    greedy = g;
-                }
-
                 if ((!isStackDemagnetized && !isEntityDemagnetized) && greedy != null && greedy.canPickupItem(item)
                         && ItemHandlerHelper.insertItemStacked(inv, stack, true).getCount() != stack.getCount())
                     return item;
             }
+            return null;
+        }
+
+        private GreedyFamiliarEntity getGreedyFamiliar() {
+            if (this.entity instanceof GreedyFamiliarEntity greedy)
+                return greedy;
+
+            for (Entity passenger : this.entity.getPassengers()) {
+                if (passenger instanceof GreedyFamiliarEntity greedy)
+                    return greedy;
+            }
+
             return null;
         }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/GreedyFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/GreedyFamiliarEntity.java
@@ -421,7 +421,14 @@ public class GreedyFamiliarEntity extends FamiliarEntity implements IFilterConfi
                 boolean isStackDemagnetized = false;//TODO: Find what the updated convention is for stack.hasTag() && stack.getTag().getBoolean("PreventRemoteMovement");
                 boolean isEntityDemagnetized = item.getPersistentData().getBoolean("PreventRemoteMovement");
 
-                if ((!isStackDemagnetized && !isEntityDemagnetized) && this.entity instanceof GreedyFamiliarEntity greedy && greedy.canPickupItem(item)
+                GreedyFamiliarEntity greedy = null;
+                if (this.entity instanceof GreedyFamiliarEntity g) {
+                    greedy = g;
+                } else if (this.entity.getFirstPassenger() instanceof GreedyFamiliarEntity g) {
+                    greedy = g;
+                }
+
+                if ((!isStackDemagnetized && !isEntityDemagnetized) && greedy != null && greedy.canPickupItem(item)
                         && ItemHandlerHelper.insertItemStacked(inv, stack, true).getCount() != stack.getCount())
                     return item;
             }

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/ShubNiggurathFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/ShubNiggurathFamiliarEntity.java
@@ -110,7 +110,6 @@ public class ShubNiggurathFamiliarEntity extends FamiliarEntity {
         if (friend != null) {
             Vec3 direction = this.position().vectorTo(friend.position());
             float rot = (float) Math.toDegrees(Mth.atan2(direction.z, direction.x)) - 50;
-            this.yRotO = this.yRotO;
             this.yRotO = rot;
             this.yBodyRot = this.yRotO;
             this.yBodyRotO = this.yRotO;


### PR DESCRIPTION
I have addressed the issue where familiars (such as the Greedy Familiar and Shub Niggurath) would stop their AI when pairing up (one riding another).

The fix involves:
1. Overriding `getControllingPassenger()` in `FamiliarEntity` to return `null`. This prevents the rider from being considered the "controller" of the mount, which was causing the mount's AI to pause in Minecraft 1.21.1.
2. Updating `GreedyFamiliarEntity`'s `FindItemGoal` to correctly identify its own settings when it's riding another entity (like the Dragon). This allows the Dragon to pick up items for the Greedy Familiar as intended.
3. Adding `FollowMobGoal` to `CthulhuFamiliarEntity` so it can be attracted to other familiars (specifically Shub Niggurath) to initiate their pairing behavior.
4. Performing a small cleanup in `ShubNiggurathFamiliarEntity`.
5. Fixing a compilation error introduced by a missing `Nullable` import.

I have verified the changes by compiling the project successfully.

---
*PR created automatically by Jules for task [488206339090173010](https://jules.google.com/task/488206339090173010) started by @klikli-dev*