### PR TITLE
fix: backport familiar AI riding fixes to 26.1.1

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/CthulhuFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/CthulhuFamiliarEntity.java
@@ -44,6 +44,7 @@ import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.control.MoveControl;
+import net.minecraft.world.entity.ai.goal.FollowMobGoal;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
 import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
@@ -98,6 +99,7 @@ public class CthulhuFamiliarEntity extends FamiliarEntity {
         this.goalSelector.addGoal(3, new FollowOwnerWaterGoal(this, 1, 3, 1));
         this.goalSelector.addGoal(4, new GiveFlowerGoal(this));
         this.goalSelector.addGoal(5, new RandomStrollGoal(this, 1.0D));
+        this.goalSelector.addGoal(6, new FollowMobGoal(this, 1, 3, 7));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/FamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/FamiliarEntity.java
@@ -65,6 +65,7 @@ import net.minecraft.world.level.storage.ValueOutput;
 import net.minecraft.util.ProblemReporter;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.UUID;
@@ -244,6 +245,12 @@ public abstract class FamiliarEntity extends PathfinderMob implements IFamiliar 
     @Override
     public Entity getFamiliarEntity() {
         return this;
+    }
+
+    @Nullable
+    @Override
+    public LivingEntity getControllingPassenger() {
+        return null;
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/GreedyFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/GreedyFamiliarEntity.java
@@ -432,6 +432,9 @@ public class GreedyFamiliarEntity extends FamiliarEntity implements IFilterConfi
                 return null;
 
             var inv = PlayerInventoryWrapper.of(player).getMainSlots();
+            GreedyFamiliarEntity greedy = this.getGreedyFamiliar();
+            if (greedy == null)
+                return null;
 
             for (ItemEntity item : this.entity.level().getEntitiesOfClass(ItemEntity.class,
                     this.entity.getBoundingBox().inflate(RANGE), e -> e.isAlive())) {
@@ -441,10 +444,22 @@ public class GreedyFamiliarEntity extends FamiliarEntity implements IFilterConfi
                 boolean isEntityDemagnetized = item.getPersistentData().getBoolean("PreventRemoteMovement").orElse(false);
 
                 if ((!isStackDemagnetized && !isEntityDemagnetized)
-                        && this.entity instanceof GreedyFamiliarEntity greedy && greedy.canPickupItem(item)
+                        && greedy.canPickupItem(item)
                         && com.klikli_dev.occultism.util.ItemTransferUtil.insertItemStacked(inv, stack, true).getCount() != stack.getCount())
                     return item;
             }
+            return null;
+        }
+
+        private GreedyFamiliarEntity getGreedyFamiliar() {
+            if (this.entity instanceof GreedyFamiliarEntity greedy)
+                return greedy;
+
+            for (Entity passenger : this.entity.getPassengers()) {
+                if (passenger instanceof GreedyFamiliarEntity greedy)
+                    return greedy;
+            }
+
             return null;
         }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/familiar/ShubNiggurathFamiliarEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/familiar/ShubNiggurathFamiliarEntity.java
@@ -110,7 +110,6 @@ public class ShubNiggurathFamiliarEntity extends FamiliarEntity {
         if (friend != null) {
             Vec3 direction = this.position().vectorTo(friend.position());
             float rot = (float) Math.toDegrees(Mth.atan2(direction.z, direction.x)) - 50;
-            this.yRotO = this.yRotO;
             this.yRotO = rot;
             this.yBodyRot = this.yRotO;
             this.yBodyRotO = this.yRotO;


### PR DESCRIPTION
## Summary
- backport the familiar riding AI fix from #1532 to version/26.1.1
- keep mounted familiars from disabling mount AI and allow dragon-mounted greedy familiars to find pickup targets correctly
- add Cthulhu follow behavior and carry over the small Shub Niggurath cleanup

## Validation
- ./gradlew.bat compileJava

Backports #1532