### PR TITLE
fix: restore storage controller GUI widgets

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/client/gui/storage/StorageControllerGuiBase.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/storage/StorageControllerGuiBase.java
@@ -287,6 +287,7 @@ public abstract class StorageControllerGuiBase<T extends StorageControllerContai
         if (OccultismJeiIntegration.get().isLoaded() && JeiSettings.isJeiSearchSynced()) {
             this.searchBar.setValue(OccultismJeiIntegration.get().getFilterText());
         }
+        this.addRenderableWidget(this.searchBar);
 
         int storageSpaceInfoLabelLeft = 186;
         int storageSpaceInfoLabelTop = 35 + 18*this.rows;
@@ -361,6 +362,7 @@ public abstract class StorageControllerGuiBase<T extends StorageControllerContai
         }
 
         this.drawBackgroundTexture(guiGraphics);
+        super.extractContents(guiGraphics, mouseX, mouseY, partialTicks);
 
         switch (this.guiMode) {
             case INVENTORY:

--- a/src/main/java/com/klikli_dev/occultism/client/gui/storage/StorageControllerGuiBase.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/storage/StorageControllerGuiBase.java
@@ -279,7 +279,7 @@ public abstract class StorageControllerGuiBase<T extends StorageControllerContai
 
         this.searchBar.setBordered(false);
         this.searchBar.setVisible(true);
-        this.searchBar.setTextColor(OccultismConstants.Color.WHITE);
+        this.searchBar.setTextColor(0xFFFFFFFF);
         this.searchBar.setFocused(focus);
 
         this.searchBar.setValue(searchBarText);


### PR DESCRIPTION
## Summary
- restore storage controller screen extraction so vanilla menu slots and registered widgets render again on 26.1
- register the search bar as a renderable widget so it can render and accept text input
- keep the custom background pass while letting the base container screen extract its slots and controls

## Validation
- ./gradlew.bat compileJava