### PR TITLE
fix: stop syncing oversized storage controller items

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/StorageControllerBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/StorageControllerBlockEntity.java
@@ -625,8 +625,9 @@ public class StorageControllerBlockEntity extends NetworkedBlockEntity implement
         if (pComponentInput.get(OccultismDataComponents.ORDER_STACK) != null)
             this.orderStack = ItemStack.OPTIONAL_CODEC.parse(this.level.registryAccess().createSerializationContext(NbtOps.INSTANCE), pComponentInput.get(OccultismDataComponents.ORDER_STACK).copyTag()).result().orElse(ItemStack.EMPTY);
 
-        if (pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS.get()) != null) {
-            this.itemStackHandler.deserializeNBT(this.level.registryAccess(), pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS.get()).copyTag());
+        var storageContents = pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS.get());
+        if (storageContents != null && !storageContents.isEmpty()) {
+            this.itemStackHandler.deserializeNBT(this.level.registryAccess(), storageContents.copyTag());
         }
     }
 
@@ -641,17 +642,22 @@ public class StorageControllerBlockEntity extends NetworkedBlockEntity implement
 
         pComponents.set(OccultismDataComponents.ORDER_STACK, CustomData.of((CompoundTag) ItemStack.OPTIONAL_CODEC.encodeStart(this.level.registryAccess().createSerializationContext(NbtOps.INSTANCE), this.orderStack).getOrThrow()));
 
-        pComponents.set(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS, CustomData.of(this.itemStackHandler.serializeNBT(this.level.registryAccess())));
+        var storageContents = this.itemStackHandler.serializeNBT(this.level.registryAccess());
+        if (!storageContents.isEmpty()) {
+            pComponents.set(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS, CustomData.of(storageContents));
+        }
     }
 
-    public void removeComponentsFromTag(CompoundTag pTag) {
-        //this causes stuff to get lost. Not sure why / how it is used in vanilla shulker boxes
-//        pTag.remove("items");
-//        pTag.remove("matrix");
-//        pTag.remove("orderStack");
-//        pTag.remove("sortDirection");
-//        pTag.remove("sortType");
-//        pTag.remove("linkedMachines");
+    @Override
+    public void removeComponentsFromTag(ValueOutput output) {
+        output.discard("items");
+        output.discard("sortDirection");
+        output.discard("sortType");
+        output.discard("matrix");
+        output.discard("orderStack");
+        output.discard("linkedMachines");
+        output.discard("maxItemTypes");
+        output.discard("maxTotalItemCount");
     }
 
     @Nullable

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/StorageControllerBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/StorageControllerBlockEntity.java
@@ -625,7 +625,7 @@ public class StorageControllerBlockEntity extends NetworkedBlockEntity implement
         if (pComponentInput.get(OccultismDataComponents.ORDER_STACK) != null)
             this.orderStack = ItemStack.OPTIONAL_CODEC.parse(this.level.registryAccess().createSerializationContext(NbtOps.INSTANCE), pComponentInput.get(OccultismDataComponents.ORDER_STACK).copyTag()).result().orElse(ItemStack.EMPTY);
 
-        var storageContents = pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS.get());
+        var storageContents = pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS);
         if (storageContents != null && !storageContents.isEmpty()) {
             this.itemStackHandler.deserializeNBT(this.level.registryAccess(), storageContents.copyTag());
         }

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
@@ -11,7 +11,9 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.Block;
@@ -22,6 +24,16 @@ import java.util.UUID;
 
 public class OccultismDataComponents {
     public static final DeferredRegister.DataComponents DATA_COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, Occultism.MODID);
+    private static final StreamCodec<RegistryFriendlyByteBuf, CustomData> STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC = new StreamCodec<>() {
+        @Override
+        public CustomData decode(RegistryFriendlyByteBuf buffer) {
+            return CustomData.EMPTY;
+        }
+
+        @Override
+        public void encode(RegistryFriendlyByteBuf buffer, CustomData value) {
+        }
+    };
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> MAX_MINING_TIME = DATA_COMPONENTS.registerComponentType("max_mining_time", builder -> builder
             .persistent(Codec.INT)
@@ -61,7 +73,7 @@ public class OccultismDataComponents {
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<CustomData>> STORAGE_CONTROLLER_CONTENTS = DATA_COMPONENTS.registerComponentType("storage_controller_contents", builder -> builder
             .persistent(CustomData.CODEC)
-            .networkSynchronized(CustomData.STREAM_CODEC)
+            .networkSynchronized(STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC)
             .cacheEncoding()
     );
 


### PR DESCRIPTION
Fixes #1495

## Summary
- move storage controller contents to a lossy network data-component codec so dropped actuator items no longer sync their full stored inventory to clients
- keep the full persistent component for item-to-block transfer while ignoring empty network values during placement
- strip duplicated storage/controller state from pick-block block-entity data so creative cloning does not reintroduce oversized payloads

## Validation
- ./gradlew.bat compileJava