### PR TITLE
fix: backport oversized storage controller sync fix to 1.21.1

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/StorageControllerBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/StorageControllerBlockEntity.java
@@ -618,8 +618,9 @@ public class StorageControllerBlockEntity extends NetworkedBlockEntity implement
         if (pComponentInput.get(OccultismDataComponents.ORDER_STACK) != null)
             this.orderStack = ItemStack.parseOptional(this.level.registryAccess(), pComponentInput.get(OccultismDataComponents.ORDER_STACK).getUnsafe());
 
-        if (pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS.get()) != null) {
-            this.itemStackHandler.deserializeNBT(this.level.registryAccess(), pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS.get()).getUnsafe());
+        var storageContents = pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS.get());
+        if (storageContents != null && !storageContents.isEmpty()) {
+            this.itemStackHandler.deserializeNBT(this.level.registryAccess(), storageContents.copyTag());
         }
     }
 
@@ -634,18 +635,22 @@ public class StorageControllerBlockEntity extends NetworkedBlockEntity implement
 
         pComponents.set(OccultismDataComponents.ORDER_STACK, CustomData.of((CompoundTag) this.orderStack.saveOptional(this.level.registryAccess())));
 
-        pComponents.set(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS, CustomData.of(this.itemStackHandler.serializeNBT(this.level.registryAccess())));
+        var storageContents = this.itemStackHandler.serializeNBT(this.level.registryAccess());
+        if (!storageContents.isEmpty()) {
+            pComponents.set(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS, CustomData.of(storageContents));
+        }
     }
 
     @Override
     public void removeComponentsFromTag(CompoundTag pTag) {
-        //this causes stuff to get lost. Not sure why / how it is used in vanilla shulker boxes
-//        pTag.remove("items");
-//        pTag.remove("matrix");
-//        pTag.remove("orderStack");
-//        pTag.remove("sortDirection");
-//        pTag.remove("sortType");
-//        pTag.remove("linkedMachines");
+        pTag.remove("items");
+        pTag.remove("sortDirection");
+        pTag.remove("sortType");
+        pTag.remove("matrix");
+        pTag.remove("orderStack");
+        pTag.remove("linkedMachines");
+        pTag.remove("maxItemTypes");
+        pTag.remove("maxTotalItemCount");
     }
 
     @Nullable

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/StorageControllerBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/StorageControllerBlockEntity.java
@@ -618,7 +618,7 @@ public class StorageControllerBlockEntity extends NetworkedBlockEntity implement
         if (pComponentInput.get(OccultismDataComponents.ORDER_STACK) != null)
             this.orderStack = ItemStack.parseOptional(this.level.registryAccess(), pComponentInput.get(OccultismDataComponents.ORDER_STACK).getUnsafe());
 
-        var storageContents = pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS.get());
+        var storageContents = pComponentInput.get(OccultismDataComponents.STORAGE_CONTROLLER_CONTENTS);
         if (storageContents != null && !storageContents.isEmpty()) {
             this.itemStackHandler.deserializeNBT(this.level.registryAccess(), storageContents.copyTag());
         }

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
@@ -11,8 +11,10 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -22,6 +24,16 @@ import java.util.UUID;
 
 public class OccultismDataComponents {
     public static final DeferredRegister.DataComponents DATA_COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, Occultism.MODID);
+    private static final StreamCodec<RegistryFriendlyByteBuf, CustomData> STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC = new StreamCodec<>() {
+        @Override
+        public CustomData decode(RegistryFriendlyByteBuf buffer) {
+            return CustomData.EMPTY;
+        }
+
+        @Override
+        public void encode(RegistryFriendlyByteBuf buffer, CustomData value) {
+        }
+    };
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> MAX_MINING_TIME = DATA_COMPONENTS.registerComponentType("max_mining_time", builder -> builder
             .persistent(Codec.INT)
@@ -61,7 +73,7 @@ public class OccultismDataComponents {
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<CustomData>> STORAGE_CONTROLLER_CONTENTS = DATA_COMPONENTS.registerComponentType("storage_controller_contents", builder -> builder
             .persistent(CustomData.CODEC)
-            .networkSynchronized(CustomData.STREAM_CODEC)
+            .networkSynchronized(STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC)
             .cacheEncoding()
     );
 

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
@@ -13,8 +13,8 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -24,16 +24,7 @@ import java.util.UUID;
 
 public class OccultismDataComponents {
     public static final DeferredRegister.DataComponents DATA_COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, Occultism.MODID);
-    private static final StreamCodec<RegistryFriendlyByteBuf, CustomData> STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC = new StreamCodec<>() {
-        @Override
-        public CustomData decode(RegistryFriendlyByteBuf buffer) {
-            return CustomData.EMPTY;
-        }
-
-        @Override
-        public void encode(RegistryFriendlyByteBuf buffer, CustomData value) {
-        }
-    };
+    private static final StreamCodec<RegistryFriendlyByteBuf, CustomData> STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC = StreamCodec.unit(CustomData.EMPTY);
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> MAX_MINING_TIME = DATA_COMPONENTS.registerComponentType("max_mining_time", builder -> builder
             .persistent(Codec.INT)


### PR DESCRIPTION
## Summary
- backport PR #1536 to ersion/1.21.1
- stop syncing oversized storage controller contents over the network while keeping persistent item/block transfer data intact
- strip duplicated storage controller block-entity keys from block item payloads to avoid reintroducing oversized data on placement or pick block

## Validation
- ./gradlew.bat compileJava