### PR TITLE
fix: prevent greedy familiar hand-slot render crash (#1540)

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/client/render/entity/GreedyFamiliarRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/entity/GreedyFamiliarRenderer.java
@@ -109,10 +109,8 @@ public class GreedyFamiliarRenderer extends MobRenderer<GreedyFamiliarEntity, Gr
 
             GreedyFamiliarModel model = this.getParentModel();
             ItemInHandRenderer renderer = Minecraft.getInstance().getEntityRenderDispatcher().getItemInHandRenderer();
-            pMatrixStack.pushPose();
-
-
             if (hasBlacksmithUpgrade) {
+                pMatrixStack.pushPose();
                 model.body.translateAndRotate(pMatrixStack);
                 model.rightArm.translateAndRotate(pMatrixStack);
 


### PR DESCRIPTION
## Summary
- fix the Greedy Familiar item layer so each render path manages its own PoseStack push/pop pair
- prevent the client and world-load crash triggered by putting an item into the familiar hand slot
- mirrors the safer per-item pose handling used by the Janitor spirit's equivalent UI flow

## Validation
- ./gradlew.bat compileJava
- reviewed render paths for blacksmith upgrade only, offhand item only, and both