### PR TITLE
fix: restore GUI slot rendering across container screens

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/client/gui/DimensionalBattlefieldScreen.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/DimensionalBattlefieldScreen.java
@@ -78,6 +78,8 @@ public class DimensionalBattlefieldScreen extends AbstractContainerScreen<Dimens
             guiGraphics.blit(RenderPipelines.GUI_TEXTURED, TEXTURE, this.leftPos + 14, this.topPos + 59, (float) 176, (float) 20, 16, 16, 256, 256);
         if (isEmpty(this.otherworldButcher.inputFuelHandler))
             guiGraphics.blit(RenderPipelines.GUI_TEXTURED, TEXTURE, this.leftPos + 40, this.topPos + 59, (float) 176, (float) 36, 16, 16, 256, 256);
+
+        super.extractContents(guiGraphics, mouseX, mouseY, partialTicks);
     }
 
 }

--- a/src/main/java/com/klikli_dev/occultism/client/gui/DimensionalMineshaftScreen.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/DimensionalMineshaftScreen.java
@@ -67,6 +67,8 @@ public class DimensionalMineshaftScreen extends AbstractContainerScreen<Dimensio
         }
         if (this.otherworldMiner.inputHandler.getStackInSlot(0).isEmpty())
             guiGraphics.blit(RenderPipelines.GUI_TEXTURED, TEXTURE, this.leftPos + 26, this.topPos + 35, (float) 176, (float) 4, 16, 16, 256, 256);
+
+        super.extractContents(guiGraphics, mouseX, mouseY, partialTicks);
     }
 
 }

--- a/src/main/java/com/klikli_dev/occultism/client/gui/satchel/RitualSatchelScreen.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/satchel/RitualSatchelScreen.java
@@ -63,5 +63,6 @@ public class RitualSatchelScreen extends AbstractContainerScreen<AbstractSatchel
     public void extractContents(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
         guiGraphics.blit(RenderPipelines.GUI_TEXTURED, BACKGROUND, this.leftPos, this.topPos, (float) 0, (float) 0, this.imageWidth,
                 this.imageHeight, 256, 256);
+        super.extractContents(guiGraphics, mouseX, mouseY, partialTicks);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/client/gui/satchel/SatchelScreen.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/satchel/SatchelScreen.java
@@ -63,5 +63,6 @@ public class SatchelScreen extends AbstractContainerScreen<AbstractSatchelContai
     public void extractContents(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
         guiGraphics.blit(RenderPipelines.GUI_TEXTURED, BACKGROUND, this.leftPos, this.topPos, (float) 0, (float) 0, this.imageWidth,
                 this.imageHeight, 256, 256);
+        super.extractContents(guiGraphics, mouseX, mouseY, partialTicks);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/client/gui/spirit/SpiritGui.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/spirit/SpiritGui.java
@@ -113,12 +113,18 @@ public class SpiritGui<T extends SpiritContainer> extends AbstractContainerScree
     public void extractContents(GuiGraphicsExtractor guiGraphics, int x, int y, float partialTicks) {
 //        this.renderBackground(guiGraphics); //called by super
 
-        guiGraphics.blit(RenderPipelines.GUI_TEXTURED, TEXTURE, this.leftPos, this.topPos, 0.0F, 0.0F, this.imageWidth, this.imageHeight, 256, 256);
+        guiGraphics.blit(RenderPipelines.GUI_TEXTURED, this.getTexture(), this.leftPos, this.topPos, 0.0F, 0.0F, this.imageWidth, this.imageHeight, 256, 256);
 
         guiGraphics.pose().pushMatrix();
         int scale = 30;
         drawEntityToGui(guiGraphics, this.leftPos + 35, this.topPos + 65, scale, this.leftPos + 51 - x,
                 this.topPos + 75 - 50 - y, this.spirit.getEntity());
         guiGraphics.pose().popMatrix();
+
+        super.extractContents(guiGraphics, x, y, partialTicks);
+    }
+
+    protected Identifier getTexture() {
+        return TEXTURE;
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/client/gui/spirit/SpiritTransporterGui.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/spirit/SpiritTransporterGui.java
@@ -129,14 +129,8 @@ public class SpiritTransporterGui extends SpiritGui<SpiritTransporterContainer> 
 
 
     @Override
-    public void extractContents(GuiGraphicsExtractor guiGraphics, int x, int y, float partialTicks) {
-        guiGraphics.blit(RenderPipelines.GUI_TEXTURED, TEXTURE, this.leftPos, this.topPos, 0.0F, 0.0F, this.imageWidth, this.imageHeight, 256, 256);
-
-        guiGraphics.pose().pushMatrix();
-        int scale = 30;
-        drawEntityToGui(guiGraphics, this.leftPos + 35, this.topPos + 65, scale, this.leftPos + 51 - x,
-                this.topPos + 75 - 50 - y, this.spirit.getEntity());
-        guiGraphics.pose().popMatrix();
+    protected Identifier getTexture() {
+        return TEXTURE;
     }
 
     protected void renderFg(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {


### PR DESCRIPTION
## Summary
- restore Greedy Familiar slot rendering and interaction by delegating the shared spirit screen extractContents path back to AbstractContainerScreen
- restore slot and player inventory rendering in satchel, ritual satchel, dimensional mineshaft, and dimensional battlefield screens using the same NeoForge 26.1 fix pattern as the storage controller GUI
- verify the container GUI sweep with ./gradlew.bat compileJava