### PR TITLE
fix: restrict mob head loot modifiers to matching entities

### DIFF
--- a/src/generated/resources/data/occultism/loot_modifiers/head_from_creeper.json
+++ b/src/generated/resources/data/occultism/loot_modifiers/head_from_creeper.json
@@ -8,7 +8,9 @@
     {
       "condition": "minecraft:entity_properties",
       "entity": "this",
-      "predicate": {}
+      "predicate": {
+        "type": "minecraft:creeper"
+      }
     }
   ],
   "count": 1,

--- a/src/generated/resources/data/occultism/loot_modifiers/head_from_dragon.json
+++ b/src/generated/resources/data/occultism/loot_modifiers/head_from_dragon.json
@@ -8,7 +8,9 @@
     {
       "condition": "minecraft:entity_properties",
       "entity": "this",
-      "predicate": {}
+      "predicate": {
+        "type": "minecraft:ender_dragon"
+      }
     }
   ],
   "count": 1,

--- a/src/generated/resources/data/occultism/loot_modifiers/head_from_piglin.json
+++ b/src/generated/resources/data/occultism/loot_modifiers/head_from_piglin.json
@@ -8,7 +8,9 @@
     {
       "condition": "minecraft:entity_properties",
       "entity": "this",
-      "predicate": {}
+      "predicate": {
+        "type": "minecraft:piglin"
+      }
     }
   ],
   "count": 1,

--- a/src/generated/resources/data/occultism/loot_modifiers/head_from_skeleton.json
+++ b/src/generated/resources/data/occultism/loot_modifiers/head_from_skeleton.json
@@ -8,7 +8,9 @@
     {
       "condition": "minecraft:entity_properties",
       "entity": "this",
-      "predicate": {}
+      "predicate": {
+        "type": "minecraft:skeleton"
+      }
     }
   ],
   "count": 1,

--- a/src/generated/resources/data/occultism/loot_modifiers/head_from_wither_skeleton.json
+++ b/src/generated/resources/data/occultism/loot_modifiers/head_from_wither_skeleton.json
@@ -8,7 +8,9 @@
     {
       "condition": "minecraft:entity_properties",
       "entity": "this",
-      "predicate": {}
+      "predicate": {
+        "type": "minecraft:wither_skeleton"
+      }
     }
   ],
   "count": 1,

--- a/src/generated/resources/data/occultism/loot_modifiers/head_from_zombie.json
+++ b/src/generated/resources/data/occultism/loot_modifiers/head_from_zombie.json
@@ -8,7 +8,9 @@
     {
       "condition": "minecraft:entity_properties",
       "entity": "this",
-      "predicate": {}
+      "predicate": {
+        "type": "minecraft:zombie"
+      }
     }
   ],
   "count": 1,

--- a/src/main/java/com/klikli_dev/occultism/datagen/loot/OccultismLootModifiers.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/loot/OccultismLootModifiers.java
@@ -52,11 +52,15 @@ public class OccultismLootModifiers extends GlobalLootModifierProvider {
     }
 
     private AddItemModifier head(EntityType<?> entityType, Item head, float chance) {
+        var entityTypeRegistry = this.registries.lookupOrThrow(Registries.ENTITY_TYPE);
         return new AddItemModifier(
                 new LootItemCondition[]{
                         LootItemRandomChanceCondition.randomChance(chance).build(),
                         LootItemEntityPropertyCondition
-                                .hasProperties(LootContext.EntityTarget.THIS, EntityPredicate.Builder.entity().build()).build()
+                                .hasProperties(LootContext.EntityTarget.THIS,
+                                        EntityPredicate.Builder.entity()
+                                                .of(entityTypeRegistry, entityType)
+                                                .build()).build()
                 }, head, 1);
     }
 


### PR DESCRIPTION
## Summary
- restrict generated mob head global loot modifiers to the matching entity type instead of an empty `this` entity predicate
- stop mob head GLMs from firing in unrelated loot contexts like block breaks and chest loot on NeoForge 26.1.2
- regenerate the affected `head_from_*` loot modifier data files

Closes #1539

## Validation
- `./gradlew.bat runData`
- `./gradlew.bat clean compileJava`
