### PR TITLE
fix: handle JEI spirit fire recipe preview without input

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/crafting/recipe/SpiritFireRecipe.java
+++ b/src/main/java/com/klikli_dev/occultism/crafting/recipe/SpiritFireRecipe.java
@@ -85,7 +85,9 @@ public class SpiritFireRecipe implements Recipe<SingleRecipeInput> {
     @Override
     public ItemStack assemble(SingleRecipeInput input) {
         ItemStack assembled = this.result.create();
-        assembled.setCount(input.getItem(0).getCount());
+        if (input != null) {
+            assembled.setCount(input.getItem(0).getCount());
+        }
         return assembled;
     }
 


### PR DESCRIPTION
## Summary
- make SpiritFireRecipe.assemble tolerate a null SingleRecipeInput during recipe preview generation
- preserve Spirit Fire recipe output previews in JEI without crashing world load
- validated with ./gradlew.bat compileJava