### PR TITLE
feat: restore food effects and fix otherworld block items and effect icons

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/effect/DoubleJumpEffect.java
+++ b/src/main/java/com/klikli_dev/occultism/common/effect/DoubleJumpEffect.java
@@ -33,7 +33,7 @@ import net.minecraft.world.entity.player.Player;
 public class DoubleJumpEffect extends MobEffect {
 
     public static final Identifier ICON = Identifier.fromNamespaceAndPath(Occultism.MODID,
-            "textures/mob_effect/double_jump.png");
+            "mob_effect/double_jump");
 
     public DoubleJumpEffect() {
         super(MobEffectCategory.BENEFICIAL, 0xffff00);

--- a/src/main/java/com/klikli_dev/occultism/common/effect/ThirdEyeEffect.java
+++ b/src/main/java/com/klikli_dev/occultism/common/effect/ThirdEyeEffect.java
@@ -30,7 +30,7 @@ import net.minecraft.world.effect.MobEffectCategory;
 public class ThirdEyeEffect extends MobEffect {
 
     public static final Identifier ICON = Identifier.fromNamespaceAndPath(Occultism.MODID,
-            "textures/mob_effect/third_eye.png");
+            "mob_effect/third_eye");
 
     public ThirdEyeEffect() {
         super(MobEffectCategory.BENEFICIAL, 0xffff00);

--- a/src/main/java/com/klikli_dev/occultism/handlers/ClientSetupEventHandler.java
+++ b/src/main/java/com/klikli_dev/occultism/handlers/ClientSetupEventHandler.java
@@ -261,22 +261,21 @@ public class ClientSetupEventHandler {
         event.registerMobEffect(new IClientMobEffectExtensions() {
             @Override
             public boolean renderGuiIcon(@NotNull MobEffectInstance instance, @NotNull Gui gui, @NotNull GuiGraphicsExtractor guiGraphics, int x, int y, float z, float alpha) {
-                guiGraphics.blit(RenderPipelines.GUI_TEXTURED, ThirdEyeEffect.ICON, x + 3, y + 3, 0.0F, 0.0F, 18, 18, 256, 256);
+                guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, Gui.getMobEffectSprite(instance.getEffect()), x + 3, y + 3, 18, 18, net.minecraft.util.ARGB.white(alpha));
                 return true;
             }
-
         }, OccultismEffects.THIRD_EYE.get());
 
-        event.registerMobEffect( new IClientMobEffectExtensions() {
+        event.registerMobEffect(new IClientMobEffectExtensions() {
             @Override
             public boolean renderInventoryIcon(@NotNull MobEffectInstance instance, @NotNull AbstractContainerScreen<?> screen, @NotNull GuiGraphicsExtractor guiGraphics, int x, int y, int blitOffset) {
-                guiGraphics.blit(RenderPipelines.GUI_TEXTURED, DoubleJumpEffect.ICON, x + 6, y + 7, 0.0F, 0.0F, 18, 18, 256, 256);
-                return false;
+                guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, Gui.getMobEffectSprite(instance.getEffect()), x, y + 7, 18, 18);
+                return true;
             }
 
             @Override
             public boolean renderGuiIcon(@NotNull MobEffectInstance instance, @NotNull Gui gui, @NotNull GuiGraphicsExtractor guiGraphics, int x, int y, float z, float alpha) {
-                guiGraphics.blit(RenderPipelines.GUI_TEXTURED, DoubleJumpEffect.ICON, x + 3, y + 3, 0.0F, 0.0F, 18, 18, 256, 256);
+                guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, Gui.getMobEffectSprite(instance.getEffect()), x, y + 3, 18, 18, net.minecraft.util.ARGB.white(alpha));
                 return false;
             }
         }, OccultismEffects.DOUBLE_JUMP.get());

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismBlocks.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismBlocks.java
@@ -846,7 +846,7 @@ public class OccultismBlocks {
 
         if (generateDefaultBlockItem) {
             if (name.contains("natural")) {
-                OccultismItems.ITEMS.registerItem(name, p -> new OccultismBlockItem(object.get(), p.useBlockDescriptionPrefix()));
+                OccultismItems.ITEMS.registerItem(name, p -> new OccultismBlockItem(object.get(), p.overrideDescription(object.get().getDescriptionId())));
             } else {
                 if (rarity == Rarity.COMMON) {
                     OccultismItems.ITEMS.registerItem(name, p -> new BlockItem(object.get(), p.useBlockDescriptionPrefix()));

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismFoods.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismFoods.java
@@ -25,30 +25,69 @@ package com.klikli_dev.occultism.registry;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.component.Consumable;
+import net.minecraft.world.item.component.Consumables;
+import net.minecraft.world.item.consume_effects.ApplyStatusEffectsConsumeEffect;
 import net.neoforged.neoforge.common.util.Lazy;
 
-import java.util.List;
-
 public class OccultismFoods {
-    // NOTE: Minecraft 26.1 moved food effect handling to the Consumable component API.
-    // To keep compilation simple we provide FoodProperties instances here which are
-    // accepted by Item.Properties.food(...). Effects can be migrated to Consumable
-    // later if desired.
+    // FoodProperties handles nutrition / saturation / always-edible
+    // Consumable handles effects via ApplyStatusEffectsConsumeEffect
+
     public static final Lazy<FoodProperties> DATURA = Lazy.of(
-            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).build());
+            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0).alwaysEdible().build());
+
+    public static final Consumable DATURA_CONSUMABLE = Consumable.builder()
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(OccultismEffects.THIRD_EYE, 15 * 20, 1), 0.7f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.HUNGER, 15 * 20, 1), 1.0f))
+            .build();
 
     public static final Lazy<FoodProperties> DEMONS_DREAM_ESSENCE = Lazy.of(
-            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).build());
+            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0).alwaysEdible().build());
+
+    public static final Consumable DEMONS_DREAM_ESSENCE_CONSUMABLE = Consumable.builder()
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(OccultismEffects.THIRD_EYE, 60 * 20, 1), 1.0f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.HUNGER, 15 * 20, 1), 1.0f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.DARKNESS, 15 * 20, 1), 0.2f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.GLOWING, 15 * 20, 1), 0.2f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.LUCK, 5 * 60 * 20, 1), 0.2f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.UNLUCK, 5 * 60 * 20, 1), 0.2f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.NAUSEA, 15 * 20, 1), 0.2f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.WEAKNESS, 15 * 20, 1), 0.2f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.LEVITATION, 15 * 20, 1), 0.2f))
+            .build();
 
     public static final Lazy<FoodProperties> OTHERWORLD_ESSENCE = Lazy.of(
-            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).build());
+            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0).alwaysEdible().build());
+
+    public static final Consumable OTHERWORLD_ESSENCE_CONSUMABLE = Consumable.builder()
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(OccultismEffects.THIRD_EYE, 60 * 20, 1), 1.0f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.LUCK, 5 * 60 * 20, 1), 1.0f))
+            .build();
 
     public static final Lazy<FoodProperties> BEAVER_NUGGET = Lazy.of(
-            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).build());
+            () -> new FoodProperties.Builder().nutrition(8).saturationModifier(0.8F).build());
+
+    public static final Consumable BEAVER_NUGGET_CONSUMABLE = Consumables.DEFAULT_FOOD;
+
     public static final Lazy<FoodProperties> CURSED_HONEY = Lazy.of(
-            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).build());
+            () -> new FoodProperties.Builder().nutrition(2).saturationModifier(1F).build());
+
+    public static final Consumable CURSED_HONEY_CONSUMABLE = Consumable.builder()
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.REGENERATION, 5 * 20, 1), 1.0f))
+            .build();
+
     public static final Lazy<FoodProperties> SWEET_HONEY_HEART = Lazy.of(
-            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).build());
+            () -> new FoodProperties.Builder().nutrition(5).saturationModifier(1.1F).build());
+
+    public static final Consumable SWEET_HONEY_HEART_CONSUMABLE = Consumable.builder()
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.ABSORPTION, Integer.MAX_VALUE, 9, false, false, false), 1.0f))
+            .build();
+
     public static final Lazy<FoodProperties> DEMONIC_MEAT = Lazy.of(
-            () -> new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).build());
+            () -> new FoodProperties.Builder().nutrition(11).saturationModifier(0.1F).build());
+
+    public static final Consumable DEMONIC_MEAT_CONSUMABLE = Consumable.builder()
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.FIRE_RESISTANCE, 3 * 60 * 20, 1), 1.0f))
+            .build();
 }

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismItems.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismItems.java
@@ -288,23 +288,23 @@ public class OccultismItems {
             properties -> new BlockItem(OccultismBlocks.DATURA.get(), properties.useBlockDescriptionPrefix()
                     .component(OccultismDataComponents.SOUL_VALUE, 1)));
     public static final DeferredItem<Item> DATURA = ITEMS.registerItem("datura",
-            SpiritHealingItem::new, () -> new Item.Properties().food(OccultismFoods.DATURA.get())
+            SpiritHealingItem::new, () -> new Item.Properties().food(OccultismFoods.DATURA.get(), OccultismFoods.DATURA_CONSUMABLE)
                     .component(OccultismDataComponents.SOUL_VALUE, 2));
     public static final DeferredItem<Item> DEMONS_DREAM_ESSENCE = ITEMS.registerItem("demons_dream_essence",
-            SpiritHealingItem::new, () -> new Item.Properties().food(OccultismFoods.DEMONS_DREAM_ESSENCE.get())
+            SpiritHealingItem::new, () -> new Item.Properties().food(OccultismFoods.DEMONS_DREAM_ESSENCE.get(), OccultismFoods.DEMONS_DREAM_ESSENCE_CONSUMABLE)
                     .component(OccultismDataComponents.SOUL_VALUE, 20));
 
     public static final DeferredItem<Item> OTHERWORLD_ESSENCE = ITEMS.registerItem("otherworld_essence",
-            SpiritHealingItem::new, () -> new Item.Properties().food(OccultismFoods.OTHERWORLD_ESSENCE.get())
+            SpiritHealingItem::new, () -> new Item.Properties().food(OccultismFoods.OTHERWORLD_ESSENCE.get(), OccultismFoods.OTHERWORLD_ESSENCE_CONSUMABLE)
                     .component(OccultismDataComponents.SOUL_VALUE, 32).component(OccultismDataComponents.LUCK_VALUE, 2));
     public static final DeferredItem<Item> BEAVER_NUGGET = ITEMS.registerItem("beaver_nugget",
-            Item::new, () -> new Item.Properties().food(OccultismFoods.BEAVER_NUGGET.get()));
+            Item::new, () -> new Item.Properties().food(OccultismFoods.BEAVER_NUGGET.get(), OccultismFoods.BEAVER_NUGGET_CONSUMABLE));
     public static final DeferredItem<Item> CURSED_HONEY = ITEMS.registerItem("cursed_honey",
-            Item::new, () -> new Item.Properties().food(OccultismFoods.CURSED_HONEY.get()));
+            Item::new, () -> new Item.Properties().food(OccultismFoods.CURSED_HONEY.get(), OccultismFoods.CURSED_HONEY_CONSUMABLE));
     public static final DeferredItem<Item> SWEET_HONEY_HEART = ITEMS.registerItem("sweet_honey_heart",
-            Item::new, () -> new Item.Properties().food(OccultismFoods.SWEET_HONEY_HEART.get()));
+            Item::new, () -> new Item.Properties().food(OccultismFoods.SWEET_HONEY_HEART.get(), OccultismFoods.SWEET_HONEY_HEART_CONSUMABLE));
     public static final DeferredItem<Item> DEMONIC_MEAT = ITEMS.registerItem("demonic_meat",
-            Item::new, () -> new Item.Properties().food(OccultismFoods.DEMONIC_MEAT.get()).rarity(Rarity.UNCOMMON).fireResistant());
+            Item::new, () -> new Item.Properties().food(OccultismFoods.DEMONIC_MEAT.get(), OccultismFoods.DEMONIC_MEAT_CONSUMABLE).rarity(Rarity.UNCOMMON).fireResistant());
 
     //Resources and materials
     public static final DeferredItem<Item> TALLOW = ITEMS.registerItem("tallow",


### PR DESCRIPTION
## Summary

Fixes several issues migrated from 1.21.1 to 26.1.2:

- **Food effects**: Restores food effect implementations using the new `Consumable` component API (`ApplyStatusEffectsConsumeEffect`) for all food items (datura, demons dream essence, otherworld essence, cursed honey, sweet honey heart, demonic meat)
- **Natural otherworld block items**: Uses `overrideDescription(block.getDescriptionId())` instead of `useBlockDescriptionPrefix()` so items inherit the correct block description (e.g. `block.minecraft.andesite`)
- **Effect icon rendering**: Fixes Third Eye and Double Jump icons using `blitSprite` with correct atlas sprite lookup, and corrects the sprite path identifiers (removed `textures/` prefix)
- **Double jump icon**: Properly centered in the player inventory effect slot

## Fixes

- Fixes #1555