### PR TITLE
fix: restore sacrificial bowl item rendering to match 1.21.1 defaults

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ neoForge {
 
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
             programArgument "--username=Occultism"
+            programArguments.add "--quickPlaySingleplayer"
+            programArguments.add "New World"
         }
 
         server {

--- a/src/main/java/com/klikli_dev/occultism/Occultism.java
+++ b/src/main/java/com/klikli_dev/occultism/Occultism.java
@@ -37,6 +37,8 @@ import com.klikli_dev.occultism.config.OccultismClientConfig;
 import com.klikli_dev.occultism.config.OccultismCommonConfig;
 import com.klikli_dev.occultism.config.OccultismServerConfig;
 import com.klikli_dev.occultism.config.OccultismStartupConfig;
+import com.klikli_dev.occultism.crafting.recipe.OccultismRecipeManager;
+import com.klikli_dev.occultism.crafting.recipe.OccultismRecipeManagerClient;
 import com.klikli_dev.occultism.handlers.ClientSetupEventHandler;
 import com.klikli_dev.occultism.handlers.ColorEventHandler;
 import com.klikli_dev.occultism.integration.modonomicon.PageLoaders;
@@ -76,7 +78,6 @@ public class Occultism {
     public Occultism(IEventBus modEventBus, ModContainer modContainer) {
         INSTANCE = this;
         modContainer.registerConfig(ModConfig.Type.SERVER, SERVER_CONFIG.spec);
-        modContainer.registerConfig(ModConfig.Type.COMMON, COMMON_CONFIG.spec);
         modContainer.registerConfig(ModConfig.Type.CLIENT, CLIENT_CONFIG.spec);
         modContainer.registerConfig(ModConfig.Type.STARTUP, STARTUP_CONFIG.spec);
 
@@ -117,8 +118,11 @@ public class Occultism {
 
         NeoForge.EVENT_BUS.addListener(OccultismDataStorage::onPlayerClone);
         NeoForge.EVENT_BUS.addListener(OccultismDataStorage::onJoinWorld);
+        NeoForge.EVENT_BUS.addListener(OccultismRecipeManager.get()::onDatapackSync);
 
         if (FMLEnvironment.getDist() == Dist.CLIENT) {
+            NeoForge.EVENT_BUS.addListener(OccultismRecipeManagerClient::onRecipesReceived);
+            NeoForge.EVENT_BUS.addListener(OccultismRecipeManagerClient::onClientLogout);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterMenuScreens);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterClientExtensions);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterRenderPipelines);

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
@@ -106,6 +106,11 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
                         renderState.itemToUseStacks = items.stream()
                                 .map(holder -> new ItemStack(holder.value()))
                                 .toArray(ItemStack[]::new);
+
+                        // Pre-update the itemToUseRenderState for the first item (will be updated in submit for cycling)
+                        if (!renderState.itemToUseStacks[0].isEmpty()) {
+                            this.itemModelResolver.updateForTopItem(renderState.itemToUseRenderState, renderState.itemToUseStacks[0], ItemDisplayContext.FIXED, blockEntity.getLevel(), null, 1);
+                        }
                     }
                 }
             } else {
@@ -166,13 +171,11 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
                 int index = renderState.itemToUseStacks.length == 1 ? 0 : (int) ((System.currentTimeMillis() / 2880) % renderState.itemToUseStacks.length);
                 ItemStack itemStack = renderState.itemToUseStacks[index];
                 if (!itemStack.isEmpty()) {
-                    // Create a temporary ItemStackRenderState for this item
-                    ItemStackRenderState itemStackState = new ItemStackRenderState();
-                    int seed = index + 1; // Different seed than main item
-                    this.itemModelResolver.updateForTopItem(itemStackState, itemStack, ItemDisplayContext.FIXED, null, null, seed);
+                    // Update the render state for the current index (cycling requires re-resolve)
+                    this.itemModelResolver.updateForTopItem(renderState.itemToUseRenderState, itemStack, ItemDisplayContext.FIXED, null, null, index + 1);
                     float scaleUse = getScale(itemStack) * 0.5F;
                     poseStack.scale(scaleUse, scaleUse, scaleUse);
-                    itemStackState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0);
+                    renderState.itemToUseRenderState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0);
                 }
             }
             poseStack.popPose();

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
@@ -81,14 +81,10 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
         renderState.gameTime = gameTime;
         renderState.lastChangeTime = lastChangeTime;
 
-        // Create ItemStackRenderState for the main item
+        // Update the pre-initialized ItemStackRenderState with the current item
         if (!stack.isEmpty()) {
-            ItemStackRenderState stackState = new ItemStackRenderState();
             int seed = (int) (blockEntity.getBlockPos().asLong() & 0xFFFFFFFFL);
-            this.itemModelResolver.updateForTopItem(stackState, stack, ItemDisplayContext.GROUND, blockEntity.getLevel(), null, seed);
-            renderState.itemStackRenderState = stackState;
-        } else {
-            renderState.itemStackRenderState = null;
+            this.itemModelResolver.updateForTopItem(renderState.itemStackRenderState, stack, ItemDisplayContext.GROUND, blockEntity.getLevel(), null, seed);
         }
 
         // GoldenSacrificialBowl-specific data
@@ -131,7 +127,7 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
         long gameTime = renderState.gameTime;
         long lastChangeTime = renderState.lastChangeTime;
 
-        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0 || stackRenderState == null) {
+        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0) {
             return;
         }
 

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
@@ -41,6 +41,8 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
+
+import java.util.Objects;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.Vec3;
 import org.jspecify.annotations.Nullable;
@@ -101,15 +103,26 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
 
                 // Get item to use for cycling animation
                 if (renderState.requiresItemUse) {
-                    var items = recipe.value().getItemToUse().items().toList();
-                    if (!items.isEmpty()) {
-                        renderState.itemToUseStacks = items.stream()
-                                .map(holder -> new ItemStack(holder.value()))
-                                .toArray(ItemStack[]::new);
+                    // Cache invalidation: only rebuild if recipe changed
+                    boolean recipeChanged = !Objects.equals(renderState.recipeId, renderState.cachedRecipeId);
 
-                        // Pre-update the itemToUseRenderState for the first item (will be updated in submit for cycling)
-                        if (!renderState.itemToUseStacks[0].isEmpty()) {
-                            this.itemModelResolver.updateForTopItem(renderState.itemToUseRenderState, renderState.itemToUseStacks[0], ItemDisplayContext.FIXED, blockEntity.getLevel(), null, 1);
+                    if (recipeChanged) {
+                        var items = recipe.value().getItemToUse().items().toList();
+                        if (!items.isEmpty()) {
+                            renderState.itemToUseStacks = items.stream()
+                                    .map(holder -> new ItemStack(holder.value()))
+                                    .toArray(ItemStack[]::new);
+                            renderState.cachedRecipeId = renderState.recipeId;
+                        }
+                    }
+
+                    // Compute cycling index in extract (called every frame)
+                    if (renderState.itemToUseStacks != null && renderState.itemToUseStacks.length > 0) {
+                        renderState.itemToUseIndex = renderState.itemToUseStacks.length == 1 ? 0 : (int) ((System.currentTimeMillis() / 2880) % renderState.itemToUseStacks.length);
+
+                        // Pre-update render state for current index
+                        if (!renderState.itemToUseStacks[renderState.itemToUseIndex].isEmpty()) {
+                            this.itemModelResolver.updateForTopItem(renderState.itemToUseRenderState, renderState.itemToUseStacks[renderState.itemToUseIndex], ItemDisplayContext.FIXED, blockEntity.getLevel(), null, renderState.itemToUseIndex + 1);
                         }
                     }
                 }
@@ -168,11 +181,9 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
             poseStack.pushPose();
             poseStack.translate(0, 3.2 - (0.5 + yOffset) / scale, 0);
             if (!renderState.itemUseFulfilled && renderState.requiresItemUse) {
-                int index = renderState.itemToUseStacks.length == 1 ? 0 : (int) ((System.currentTimeMillis() / 2880) % renderState.itemToUseStacks.length);
+                int index = renderState.itemToUseIndex;
                 ItemStack itemStack = renderState.itemToUseStacks[index];
                 if (!itemStack.isEmpty()) {
-                    // Update the render state for the current index (cycling requires re-resolve)
-                    this.itemModelResolver.updateForTopItem(renderState.itemToUseRenderState, itemStack, ItemDisplayContext.FIXED, null, null, index + 1);
                     float scaleUse = getScale(itemStack) * 0.5F;
                     poseStack.scale(scaleUse, scaleUse, scaleUse);
                     renderState.itemToUseRenderState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0);

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
@@ -81,6 +81,16 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
         renderState.gameTime = gameTime;
         renderState.lastChangeTime = lastChangeTime;
 
+        // Create ItemStackRenderState for the main item
+        if (!stack.isEmpty()) {
+            ItemStackRenderState stackState = new ItemStackRenderState();
+            int seed = (int) (blockEntity.getBlockPos().asLong() & 0xFFFFFFFFL);
+            this.itemModelResolver.updateForTopItem(stackState, stack, ItemDisplayContext.GROUND, blockEntity.getLevel(), null, seed);
+            renderState.itemStackRenderState = stackState;
+        } else {
+            renderState.itemStackRenderState = null;
+        }
+
         // GoldenSacrificialBowl-specific data
         if (blockEntity instanceof GoldenSacrificialBowlBlockEntity goldenBowl) {
             renderState.isGoldenBowl = true;
@@ -116,11 +126,12 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
     @Override
     public void submit(GoldenSacrificialBowlRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitCollector, CameraRenderState cameraRenderState) {
         ItemStack stack = renderState.itemStack;
+        ItemStackRenderState stackRenderState = renderState.itemStackRenderState;
         Direction facing = renderState.facing;
         long gameTime = renderState.gameTime;
         long lastChangeTime = renderState.lastChangeTime;
 
-        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0) {
+        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0 || stackRenderState == null) {
             return;
         }
 
@@ -148,8 +159,8 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
         float scale = getScale(stack) * 0.5f;
         poseStack.scale(scale, scale, scale);
 
-        // Render the main item
-        renderItem(stack, poseStack, submitCollector, renderState.lightCoords);
+        // Render the main item using the pre-created ItemStackRenderState
+        stackRenderState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
 
         // Render item-to-use indicator for GoldenSacrificialBowl
         if (renderState.isGoldenBowl && !stack.isEmpty() && renderState.itemToUseStacks != null && renderState.itemToUseStacks.length > 0) {
@@ -159,9 +170,13 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
                 int index = renderState.itemToUseStacks.length == 1 ? 0 : (int) ((System.currentTimeMillis() / 2880) % renderState.itemToUseStacks.length);
                 ItemStack itemStack = renderState.itemToUseStacks[index];
                 if (!itemStack.isEmpty()) {
+                    // Create a temporary ItemStackRenderState for this item
+                    ItemStackRenderState itemStackState = new ItemStackRenderState();
+                    int seed = index + 1; // Different seed than main item
+                    this.itemModelResolver.updateForTopItem(itemStackState, itemStack, ItemDisplayContext.GROUND, null, null, seed);
                     float scaleUse = getScale(itemStack) * 0.5F;
                     poseStack.scale(scaleUse, scaleUse, scaleUse);
-                    renderItem(itemStack, poseStack, submitCollector, renderState.lightCoords);
+                    itemStackState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
                 }
             }
             poseStack.popPose();
@@ -172,11 +187,5 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
         poseStack.mulPose(facing.getRotation());
 
         poseStack.popPose();
-    }
-
-    private void renderItem(ItemStack stack, PoseStack poseStack, SubmitNodeCollector submitCollector, int lightCoords) {
-        ItemStackRenderState stackState = new ItemStackRenderState();
-        this.itemModelResolver.updateForTopItem(stackState, stack, ItemDisplayContext.FIXED, null, null, 0);
-        stackState.submit(poseStack, submitCollector, lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
@@ -84,7 +84,7 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
         // Update the pre-initialized ItemStackRenderState with the current item
         if (!stack.isEmpty()) {
             int seed = (int) (blockEntity.getBlockPos().asLong() & 0xFFFFFFFFL);
-            this.itemModelResolver.updateForTopItem(renderState.itemStackRenderState, stack, ItemDisplayContext.GROUND, blockEntity.getLevel(), null, seed);
+            this.itemModelResolver.updateForTopItem(renderState.itemStackRenderState, stack, ItemDisplayContext.FIXED, blockEntity.getLevel(), null, seed);
         }
 
         // GoldenSacrificialBowl-specific data
@@ -156,7 +156,7 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
         poseStack.scale(scale, scale, scale);
 
         // Render the main item using the pre-created ItemStackRenderState
-        stackRenderState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
+        stackRenderState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0);
 
         // Render item-to-use indicator for GoldenSacrificialBowl
         if (renderState.isGoldenBowl && !stack.isEmpty() && renderState.itemToUseStacks != null && renderState.itemToUseStacks.length > 0) {
@@ -169,10 +169,10 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
                     // Create a temporary ItemStackRenderState for this item
                     ItemStackRenderState itemStackState = new ItemStackRenderState();
                     int seed = index + 1; // Different seed than main item
-                    this.itemModelResolver.updateForTopItem(itemStackState, itemStack, ItemDisplayContext.GROUND, null, null, seed);
+                    this.itemModelResolver.updateForTopItem(itemStackState, itemStack, ItemDisplayContext.FIXED, null, null, seed);
                     float scaleUse = getScale(itemStack) * 0.5F;
                     poseStack.scale(scaleUse, scaleUse, scaleUse);
-                    itemStackState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
+                    itemStackState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0);
                 }
             }
             poseStack.popPose();

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
@@ -22,33 +22,35 @@
 
 package com.klikli_dev.occultism.client.render.blockentity;
 
+import com.klikli_dev.occultism.client.render.blockentity.state.GoldenSacrificialBowlRenderState;
 import com.klikli_dev.occultism.common.block.SpiritAttunedCrystalBlock;
 import com.klikli_dev.occultism.common.blockentity.GoldenSacrificialBowlBlockEntity;
 import com.klikli_dev.occultism.common.blockentity.SacrificialBowlBlockEntity;
-import com.klikli_dev.occultism.util.EntityUtil;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.item.ItemModelResolver;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
-import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.Direction;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.Vec3;
+import org.jspecify.annotations.Nullable;
 
-public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<SacrificialBowlBlockEntity, BlockEntityRenderState> {
+public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<SacrificialBowlBlockEntity, GoldenSacrificialBowlRenderState> {
+
+    private final ItemModelResolver itemModelResolver;
 
     public GoldenSacrificialBowlRenderer(BlockEntityRendererProvider.Context context) {
-
+        this.itemModelResolver = context.itemModelResolver();
     }
 
     public static float getScale(ItemStack stack) {
@@ -60,99 +62,121 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
     }
 
     @Override
-    public BlockEntityRenderState createRenderState() {
-        return new BlockEntityRenderState();
+    public GoldenSacrificialBowlRenderState createRenderState() {
+        return new GoldenSacrificialBowlRenderState();
     }
 
     @Override
-    public void extractRenderState(SacrificialBowlBlockEntity blockEntity, BlockEntityRenderState renderState, float partialTick, Vec3 cameraPos, ModelFeatureRenderer.CrumblingOverlay crumbling) {
+    public void extractRenderState(SacrificialBowlBlockEntity blockEntity, GoldenSacrificialBowlRenderState renderState, float partialTick, Vec3 cameraPos, ModelFeatureRenderer.@Nullable CrumblingOverlay crumbling) {
         BlockEntityRenderer.super.extractRenderState(blockEntity, renderState, partialTick, cameraPos, crumbling);
+
+        ItemStack stack = blockEntity.itemStackHandler.getResource(0).toStack();
+        Direction facing = blockEntity.getBlockState().hasProperty(BlockStateProperties.FACING) ?
+                blockEntity.getBlockState().getValue(BlockStateProperties.FACING) : Direction.UP;
+        long gameTime = blockEntity.getLevel() != null ? blockEntity.getLevel().getGameTime() : 0L;
+        long lastChangeTime = blockEntity.lastChangeTime;
+
+        renderState.itemStack = stack;
+        renderState.facing = facing;
+        renderState.gameTime = gameTime;
+        renderState.lastChangeTime = lastChangeTime;
+
+        // GoldenSacrificialBowl-specific data
+        if (blockEntity instanceof GoldenSacrificialBowlBlockEntity goldenBowl) {
+            renderState.isGoldenBowl = true;
+
+            var recipe = goldenBowl.getCurrentRitualRecipe();
+            if (recipe != null) {
+                renderState.itemUseFulfilled = goldenBowl.itemUseFulfilled();
+                renderState.sacrificeFulfilled = goldenBowl.sacrificeFulfilled();
+                renderState.recipeId = recipe.id().toString();
+                renderState.requiresItemUse = recipe.value().requiresItemUse();
+                renderState.requiresSacrifice = recipe.value().requiresSacrifice();
+
+                // Get item to use for cycling animation
+                if (renderState.requiresItemUse) {
+                    var items = recipe.value().getItemToUse().items().toList();
+                    if (!items.isEmpty()) {
+                        renderState.itemToUseStacks = items.stream()
+                                .map(holder -> new ItemStack(holder.value()))
+                                .toArray(ItemStack[]::new);
+                    }
+                }
+            } else {
+                renderState.itemUseFulfilled = true;
+                renderState.sacrificeFulfilled = true;
+                renderState.requiresItemUse = false;
+                renderState.requiresSacrifice = false;
+            }
+        } else {
+            renderState.isGoldenBowl = false;
+        }
     }
 
     @Override
-    public void submit(BlockEntityRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitCollector, CameraRenderState cameraRenderState) {
-        // TODO: Port to 26.1 rendering API
-        // Original render logic displayed a floating, rotating item above the bowl with bobbing animation.
-        // For GoldenSacrificialBowl, also showed items-to-use and entity-to-sacrifice indicators.
-        // This needs to be ported to the new submit/extractRenderState pattern.
-    }
+    public void submit(GoldenSacrificialBowlRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitCollector, CameraRenderState cameraRenderState) {
+        ItemStack stack = renderState.itemStack;
+        Direction facing = renderState.facing;
+        long gameTime = renderState.gameTime;
+        long lastChangeTime = renderState.lastChangeTime;
 
-    // Legacy render logic preserved as reference:
-    public void render(SacrificialBowlBlockEntity blockEntity, float partialTicks, PoseStack poseStack,
-                       MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
-        var handler = blockEntity.itemStackHandler;
-        ItemStack stack = handler.getResource(0).toStack();
-        long time = blockEntity.getLevel().getGameTime();
-
-        var facing = blockEntity.getBlockState().hasProperty(BlockStateProperties.FACING) ?
-                blockEntity.getBlockState().getValue(BlockStateProperties.FACING) : Direction.UP;
+        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0) {
+            return;
+        }
 
         poseStack.pushPose();
-
         poseStack.pushPose();
 
-        //slowly bob up and down following a sine
-        double offset = Math.sin((time - blockEntity.lastChangeTime + partialTicks) / 16) * 0.5f + 0.5f; // * 0.5f + 0.5f;  move sine between 0.0-1.0
-        offset = offset / 4.0f; //reduce amplitude
+        // Calculate bobbing offset
+        double offset = Math.sin((gameTime - lastChangeTime) / 16.0) * 0.5 + 0.5;
+        offset = offset / 4.0;
 
-        // Fixed offset to push the item away from the bowl
         double fixedOffset = 0.2;
 
-        // Adjust the translation based on the facing direction
         double xOffset = facing.getAxis() == Direction.Axis.X ? (facing.getAxisDirection() == Direction.AxisDirection.POSITIVE ? offset + fixedOffset : -offset - fixedOffset) : 0.0;
         double yOffset = facing.getAxis() == Direction.Axis.Y ? (facing.getAxisDirection() == Direction.AxisDirection.POSITIVE ? offset + fixedOffset : -offset - fixedOffset) : 0.0;
         double zOffset = facing.getAxis() == Direction.Axis.Z ? (facing.getAxisDirection() == Direction.AxisDirection.POSITIVE ? offset + fixedOffset : -offset - fixedOffset) : 0.0;
 
         poseStack.translate(0.5 + xOffset, 0.5 + yOffset, 0.5 + zOffset);
 
-        //use system time to become independent of game time
+        // Rotate item around Y axis using system time
         long systemTime = System.currentTimeMillis();
-        //rotate item slowly around y axis
         float angle = (systemTime / 16) % 360;
         poseStack.mulPose(Axis.YP.rotationDegrees(angle));
 
-        //Fixed scale
+        // Scale
         float scale = getScale(stack) * 0.5f;
         poseStack.scale(scale, scale, scale);
 
-        // TODO: Port to 26.1 rendering API - BakedModel removed
-        /*
-        ItemRenderer itemRenderer = Minecraft.getInstance().getItemRenderer();
-        Level level = blockEntity.getLevel();
-        BakedModel model = itemRenderer.getModel(stack, level, null, 0);
-        itemRenderer.render(stack, ItemDisplayContext.FIXED, true, poseStack, buffer,
-                combinedLight, combinedOverlay, model);
+        // Render the main item
+        renderItem(stack, poseStack, submitCollector, renderState.lightCoords);
 
-        if (!stack.isEmpty() && blockEntity instanceof GoldenSacrificialBowlBlockEntity goldenBowl) {
-            poseStack.translate(0, 3.2 -(0.5 + yOffset)/scale, 0);
-            if (!goldenBowl.itemUseFulfilled()){
-                ItemStack[] itemStackList = goldenBowl.getCurrentRitualRecipe().value().getItemToUse().getItems();
-                if (itemStackList.length > 0) {
-                    int index = itemStackList.length == 1 ? 0 : (int) ((System.currentTimeMillis() / 2880) % itemStackList.length);
-                    ItemStack itemStack = itemStackList[index];
+        // Render item-to-use indicator for GoldenSacrificialBowl
+        if (renderState.isGoldenBowl && !stack.isEmpty() && renderState.itemToUseStacks != null && renderState.itemToUseStacks.length > 0) {
+            poseStack.pushPose();
+            poseStack.translate(0, 3.2 - (0.5 + yOffset) / scale, 0);
+            if (!renderState.itemUseFulfilled && renderState.requiresItemUse) {
+                int index = renderState.itemToUseStacks.length == 1 ? 0 : (int) ((System.currentTimeMillis() / 2880) % renderState.itemToUseStacks.length);
+                ItemStack itemStack = renderState.itemToUseStacks[index];
+                if (!itemStack.isEmpty()) {
                     float scaleUse = getScale(itemStack) * 0.5F;
                     poseStack.scale(scaleUse, scaleUse, scaleUse);
-                    BakedModel modelItem = itemRenderer.getModel(itemStack, level, null, 0);
-                    itemRenderer.render(itemStack, ItemDisplayContext.FIXED, false, poseStack, buffer,
-                            combinedLight, combinedOverlay, modelItem);
+                    renderItem(itemStack, poseStack, submitCollector, renderState.lightCoords);
                 }
             }
-            if (!goldenBowl.sacrificeFulfilled()) {
-                LivingEntity pLivingEntity = (LivingEntity) EntityUtil.getEntityInTag(level, goldenBowl.currentRitualRecipe.value().getEntityToSacrifice()).create(level);
-                if (pLivingEntity == null)
-                    return;
-                float maxSize = (float) Math.max(pLivingEntity.getHitbox().getXsize(), Math.max(pLivingEntity.getHitbox().getYsize(), pLivingEntity.getHitbox().getZsize()));
-                float eScale = 0.5F/maxSize;
-                poseStack.scale(eScale, eScale, eScale);
-                EntityUtil.renderEntity(poseStack, pLivingEntity, buffer, partialTicks);
-            }
+            poseStack.popPose();
         }
-        */
 
         poseStack.popPose();
 
         poseStack.mulPose(facing.getRotation());
 
         poseStack.popPose();
+    }
+
+    private void renderItem(ItemStack stack, PoseStack poseStack, SubmitNodeCollector submitCollector, int lightCoords) {
+        ItemStackRenderState stackState = new ItemStackRenderState();
+        this.itemModelResolver.updateForTopItem(stackState, stack, ItemDisplayContext.FIXED, null, null, 0);
+        stackState.submit(poseStack, submitCollector, lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/SacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/SacrificialBowlRenderer.java
@@ -22,29 +22,34 @@
 
 package com.klikli_dev.occultism.client.render.blockentity;
 
+import com.klikli_dev.occultism.client.render.blockentity.state.SacrificialBowlRenderState;
 import com.klikli_dev.occultism.common.block.SpiritAttunedCrystalBlock;
 import com.klikli_dev.occultism.common.blockentity.SacrificialBowlBlockEntity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.item.ItemModelResolver;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
-import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.Vec3;
+import org.jspecify.annotations.Nullable;
 
-public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialBowlBlockEntity, BlockEntityRenderState> {
+public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialBowlBlockEntity, SacrificialBowlRenderState> {
+
+    private final ItemModelResolver itemModelResolver;
 
     public SacrificialBowlRenderer(BlockEntityRendererProvider.Context context) {
-
+        this.itemModelResolver = context.itemModelResolver();
     }
 
     public static float getScale(ItemStack stack) {
@@ -56,72 +61,74 @@ public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialB
     }
 
     @Override
-    public BlockEntityRenderState createRenderState() {
-        return new BlockEntityRenderState();
+    public SacrificialBowlRenderState createRenderState() {
+        return new SacrificialBowlRenderState();
     }
 
     @Override
-    public void extractRenderState(SacrificialBowlBlockEntity blockEntity, BlockEntityRenderState renderState, float partialTick, Vec3 cameraPos, ModelFeatureRenderer.CrumblingOverlay crumbling) {
+    public void extractRenderState(SacrificialBowlBlockEntity blockEntity, SacrificialBowlRenderState renderState, float partialTick, Vec3 cameraPos, ModelFeatureRenderer.@Nullable CrumblingOverlay crumbling) {
         BlockEntityRenderer.super.extractRenderState(blockEntity, renderState, partialTick, cameraPos, crumbling);
+
+        ItemStack stack = blockEntity.itemStackHandler.getResource(0).toStack();
+        Direction facing = blockEntity.getBlockState().hasProperty(BlockStateProperties.FACING) ?
+                blockEntity.getBlockState().getValue(BlockStateProperties.FACING) : Direction.UP;
+        long gameTime = blockEntity.getLevel() != null ? blockEntity.getLevel().getGameTime() : 0L;
+        long lastChangeTime = blockEntity.lastChangeTime;
+
+        renderState.itemStack = stack;
+        renderState.facing = facing;
+        renderState.gameTime = gameTime;
+        renderState.lastChangeTime = lastChangeTime;
     }
 
     @Override
-    public void submit(BlockEntityRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitCollector, CameraRenderState cameraRenderState) {
-        // TODO: Port to 26.1 rendering API
-        // Original render logic displayed a floating, rotating item above the bowl with bobbing animation.
-        // This needs to be ported to the new submit/extractRenderState pattern.
-    }
+    public void submit(SacrificialBowlRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitCollector, CameraRenderState cameraRenderState) {
+        ItemStack stack = renderState.itemStack;
+        Direction facing = renderState.facing;
+        long gameTime = renderState.gameTime;
+        long lastChangeTime = renderState.lastChangeTime;
 
-    // Legacy render logic preserved as reference:
-    public void render(SacrificialBowlBlockEntity blockEntity, float partialTicks, PoseStack poseStack,
-                       MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
-        var handler = blockEntity.itemStackHandler;
-        ItemStack stack = handler.getResource(0).toStack();
-        long time = blockEntity.getLevel().getGameTime();
-
-        var facing = blockEntity.getBlockState().hasProperty(BlockStateProperties.FACING) ?
-                blockEntity.getBlockState().getValue(BlockStateProperties.FACING) : Direction.UP;
+        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0) {
+            return;
+        }
 
         poseStack.pushPose();
-
         poseStack.pushPose();
 
-        //slowly bob up and down following a sine
-        double offset = Math.sin((time - blockEntity.lastChangeTime + partialTicks) / 16) * 0.5f + 0.5f; // * 0.5f + 0.5f;  move sine between 0.0-1.0
-        offset = offset / 4.0f; //reduce amplitude
+        // Calculate bobbing offset
+        double offset = Math.sin((gameTime - lastChangeTime) / 16.0) * 0.5 + 0.5;
+        offset = offset / 4.0;
 
-        // Fixed offset to push the item away from the bowl
         double fixedOffset = 0.2;
 
-        // Adjust the translation based on the facing direction
         double xOffset = facing.getAxis() == Direction.Axis.X ? (facing.getAxisDirection() == Direction.AxisDirection.POSITIVE ? offset + fixedOffset : -offset - fixedOffset) : 0.0;
         double yOffset = facing.getAxis() == Direction.Axis.Y ? (facing.getAxisDirection() == Direction.AxisDirection.POSITIVE ? offset + fixedOffset : -offset - fixedOffset) : 0.0;
         double zOffset = facing.getAxis() == Direction.Axis.Z ? (facing.getAxisDirection() == Direction.AxisDirection.POSITIVE ? offset + fixedOffset : -offset - fixedOffset) : 0.0;
 
         poseStack.translate(0.5 + xOffset, 0.5 + yOffset, 0.5 + zOffset);
 
-        //use system time to become independent of game time
+        // Rotate item around Y axis using system time
         long systemTime = System.currentTimeMillis();
-        //rotate item slowly around y axis
         float angle = (systemTime / 16) % 360;
         poseStack.mulPose(Axis.YP.rotationDegrees(angle));
 
-        //Fixed scale
+        // Scale
         float scale = getScale(stack) * 0.5f;
         poseStack.scale(scale, scale, scale);
-        
-        // TODO: Port to 26.1 rendering API - BakedModel removed
-        /*
-        ItemRenderer itemRenderer = Minecraft.getInstance().getItemRenderer();
-        BakedModel model = itemRenderer.getModel(stack, blockEntity.getLevel(), null, 0);
-        itemRenderer.render(stack, ItemDisplayContext.FIXED, true, poseStack, buffer,
-                combinedLight, combinedOverlay, model);
-        */
+
+        // Render the item using the new API
+        renderItem(stack, poseStack, submitCollector, renderState.lightCoords);
 
         poseStack.popPose();
 
         poseStack.mulPose(facing.getRotation());
 
         poseStack.popPose();
+    }
+
+    private void renderItem(ItemStack stack, PoseStack poseStack, SubmitNodeCollector submitCollector, int lightCoords) {
+        ItemStackRenderState stackState = new ItemStackRenderState();
+        this.itemModelResolver.updateForTopItem(stackState, stack, ItemDisplayContext.FIXED, null, null, 0);
+        stackState.submit(poseStack, submitCollector, lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/SacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/SacrificialBowlRenderer.java
@@ -84,7 +84,7 @@ public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialB
         if (!stack.isEmpty()) {
             int seed = (int) (blockEntity.getBlockPos().asLong() & 0xFFFFFFFFL);
             // Pass null for owner since BlockEntity doesn't implement ItemOwner
-            this.itemModelResolver.updateForTopItem(renderState.itemStackRenderState, stack, ItemDisplayContext.GROUND, blockEntity.getLevel(), null, seed);
+            this.itemModelResolver.updateForTopItem(renderState.itemStackRenderState, stack, ItemDisplayContext.FIXED, blockEntity.getLevel(), null, seed);
         }
     }
 
@@ -125,7 +125,7 @@ public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialB
         poseStack.scale(scale, scale, scale);
 
         // Render the item using the pre-created ItemStackRenderState
-        stackRenderState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
+        stackRenderState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0);
 
         poseStack.popPose();
 

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/SacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/SacrificialBowlRenderer.java
@@ -80,15 +80,11 @@ public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialB
         renderState.gameTime = gameTime;
         renderState.lastChangeTime = lastChangeTime;
 
-        // Create ItemStackRenderState for the item
+        // Update the pre-initialized ItemStackRenderState with the current item
         if (!stack.isEmpty()) {
-            ItemStackRenderState stackState = new ItemStackRenderState();
             int seed = (int) (blockEntity.getBlockPos().asLong() & 0xFFFFFFFFL);
             // Pass null for owner since BlockEntity doesn't implement ItemOwner
-            this.itemModelResolver.updateForTopItem(stackState, stack, ItemDisplayContext.GROUND, blockEntity.getLevel(), null, seed);
-            renderState.itemStackRenderState = stackState;
-        } else {
-            renderState.itemStackRenderState = null;
+            this.itemModelResolver.updateForTopItem(renderState.itemStackRenderState, stack, ItemDisplayContext.GROUND, blockEntity.getLevel(), null, seed);
         }
     }
 
@@ -100,7 +96,7 @@ public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialB
         long gameTime = renderState.gameTime;
         long lastChangeTime = renderState.lastChangeTime;
 
-        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0 || stackRenderState == null) {
+        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0) {
             return;
         }
 

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/SacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/SacrificialBowlRenderer.java
@@ -79,16 +79,28 @@ public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialB
         renderState.facing = facing;
         renderState.gameTime = gameTime;
         renderState.lastChangeTime = lastChangeTime;
+
+        // Create ItemStackRenderState for the item
+        if (!stack.isEmpty()) {
+            ItemStackRenderState stackState = new ItemStackRenderState();
+            int seed = (int) (blockEntity.getBlockPos().asLong() & 0xFFFFFFFFL);
+            // Pass null for owner since BlockEntity doesn't implement ItemOwner
+            this.itemModelResolver.updateForTopItem(stackState, stack, ItemDisplayContext.GROUND, blockEntity.getLevel(), null, seed);
+            renderState.itemStackRenderState = stackState;
+        } else {
+            renderState.itemStackRenderState = null;
+        }
     }
 
     @Override
     public void submit(SacrificialBowlRenderState renderState, PoseStack poseStack, SubmitNodeCollector submitCollector, CameraRenderState cameraRenderState) {
         ItemStack stack = renderState.itemStack;
+        ItemStackRenderState stackRenderState = renderState.itemStackRenderState;
         Direction facing = renderState.facing;
         long gameTime = renderState.gameTime;
         long lastChangeTime = renderState.lastChangeTime;
 
-        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0) {
+        if (stack == null || stack.isEmpty() || facing == null || gameTime == 0 || stackRenderState == null) {
             return;
         }
 
@@ -116,19 +128,13 @@ public class SacrificialBowlRenderer implements BlockEntityRenderer<SacrificialB
         float scale = getScale(stack) * 0.5f;
         poseStack.scale(scale, scale, scale);
 
-        // Render the item using the new API
-        renderItem(stack, poseStack, submitCollector, renderState.lightCoords);
+        // Render the item using the pre-created ItemStackRenderState
+        stackRenderState.submit(poseStack, submitCollector, renderState.lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
 
         poseStack.popPose();
 
         poseStack.mulPose(facing.getRotation());
 
         poseStack.popPose();
-    }
-
-    private void renderItem(ItemStack stack, PoseStack poseStack, SubmitNodeCollector submitCollector, int lightCoords) {
-        ItemStackRenderState stackState = new ItemStackRenderState();
-        this.itemModelResolver.updateForTopItem(stackState, stack, ItemDisplayContext.FIXED, null, null, 0);
-        stackState.submit(poseStack, submitCollector, lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
@@ -23,12 +23,14 @@
 package com.klikli_dev.occultism.client.render.blockentity.state;
 
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 
 public class GoldenSacrificialBowlRenderState extends BlockEntityRenderState {
 
     public ItemStack itemStack = ItemStack.EMPTY;
+    public ItemStackRenderState itemStackRenderState = null;
     public Direction facing = Direction.UP;
     public long gameTime = 0L;
     public long lastChangeTime = 0L;

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
@@ -30,6 +30,7 @@ import net.minecraft.world.item.ItemStack;
 public class GoldenSacrificialBowlRenderState extends BlockEntityRenderState {
 
     public final ItemStackRenderState itemStackRenderState = new ItemStackRenderState();
+    public final ItemStackRenderState itemToUseRenderState = new ItemStackRenderState();
     public ItemStack itemStack = ItemStack.EMPTY;
     public Direction facing = Direction.UP;
     public long gameTime = 0L;

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
@@ -41,9 +41,11 @@ public class GoldenSacrificialBowlRenderState extends BlockEntityRenderState {
     public boolean itemUseFulfilled = true;
     public boolean sacrificeFulfilled = true;
     public String recipeId = null;
+    public String cachedRecipeId = null;
     public boolean requiresItemUse = false;
     public boolean requiresSacrifice = false;
     public ItemStack[] itemToUseStacks = null;
+    public int itemToUseIndex = 0;
 
     public GoldenSacrificialBowlRenderState() {
     }

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright 2020 klikli-dev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.klikli_dev.occultism.client.render.blockentity.state;
+
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+
+public class GoldenSacrificialBowlRenderState extends BlockEntityRenderState {
+
+    public ItemStack itemStack = ItemStack.EMPTY;
+    public Direction facing = Direction.UP;
+    public long gameTime = 0L;
+    public long lastChangeTime = 0L;
+
+    // GoldenSacrificialBowl specific
+    public boolean isGoldenBowl = false;
+    public boolean itemUseFulfilled = true;
+    public boolean sacrificeFulfilled = true;
+    public String recipeId = null;
+    public boolean requiresItemUse = false;
+    public boolean requiresSacrifice = false;
+    public ItemStack[] itemToUseStacks = null;
+
+    public GoldenSacrificialBowlRenderState() {
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/GoldenSacrificialBowlRenderState.java
@@ -29,8 +29,8 @@ import net.minecraft.world.item.ItemStack;
 
 public class GoldenSacrificialBowlRenderState extends BlockEntityRenderState {
 
+    public final ItemStackRenderState itemStackRenderState = new ItemStackRenderState();
     public ItemStack itemStack = ItemStack.EMPTY;
-    public ItemStackRenderState itemStackRenderState = null;
     public Direction facing = Direction.UP;
     public long gameTime = 0L;
     public long lastChangeTime = 0L;

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/SacrificialBowlRenderState.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/SacrificialBowlRenderState.java
@@ -29,8 +29,8 @@ import net.minecraft.world.item.ItemStack;
 
 public class SacrificialBowlRenderState extends BlockEntityRenderState {
 
+    public final ItemStackRenderState itemStackRenderState = new ItemStackRenderState();
     public ItemStack itemStack = ItemStack.EMPTY;
-    public ItemStackRenderState itemStackRenderState = null;
     public Direction facing = Direction.UP;
     public long gameTime = 0L;
     public long lastChangeTime = 0L;

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/SacrificialBowlRenderState.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/SacrificialBowlRenderState.java
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright 2020 klikli-dev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.klikli_dev.occultism.client.render.blockentity.state;
+
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+
+public class SacrificialBowlRenderState extends BlockEntityRenderState {
+
+    public ItemStack itemStack = ItemStack.EMPTY;
+    public Direction facing = Direction.UP;
+    public long gameTime = 0L;
+    public long lastChangeTime = 0L;
+
+    public SacrificialBowlRenderState() {
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/SacrificialBowlRenderState.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/state/SacrificialBowlRenderState.java
@@ -23,12 +23,14 @@
 package com.klikli_dev.occultism.client.render.blockentity.state;
 
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 
 public class SacrificialBowlRenderState extends BlockEntityRenderState {
 
     public ItemStack itemStack = ItemStack.EMPTY;
+    public ItemStackRenderState itemStackRenderState = null;
     public Direction facing = Direction.UP;
     public long gameTime = 0L;
     public long lastChangeTime = 0L;

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
@@ -30,6 +30,7 @@ import com.klikli_dev.occultism.common.item.DummyTooltipItem;
 import com.klikli_dev.occultism.common.item.spirit.BookOfBindingItem;
 import com.klikli_dev.occultism.common.item.tool.ritual_satchel.MultiBlockRitualSatchelItem;
 import com.klikli_dev.occultism.common.ritual.Ritual;
+import com.klikli_dev.occultism.crafting.recipe.OccultismRecipeManager;
 import com.klikli_dev.occultism.crafting.recipe.RitualRecipe;
 import com.klikli_dev.occultism.registry.*;
 import com.klikli_dev.occultism.util.EntityUtil;
@@ -323,13 +324,15 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
     @SuppressWarnings("unchecked")
     public RecipeHolder<RitualRecipe> getCurrentRitualRecipe() {
         if (this.currentRitualRecipeId != null) {
-            if (this.level != null && this.level instanceof ServerLevel serverLevel) {
+            if (this.level != null) {
                 var recipeKey = ResourceKey.create(Registries.RECIPE, this.currentRitualRecipeId);
-                var recipe = serverLevel.recipeAccess().byKey(recipeKey);
+                var recipe = OccultismRecipeManager.get().getRecipeByKey(OccultismRecipes.RITUAL_TYPE.get(), recipeKey, this.level);
                 recipe.map(r -> (RecipeHolder<RitualRecipe>) r).ifPresent(r -> this.currentRitualRecipe = r);
 
-                NeoForge.EVENT_BUS.addListener(this.rightClickItemListener);
-                NeoForge.EVENT_BUS.addListener(this.livingDeathEventListener);
+                if (this.level instanceof ServerLevel) {
+                    NeoForge.EVENT_BUS.addListener(this.rightClickItemListener);
+                    NeoForge.EVENT_BUS.addListener(this.livingDeathEventListener);
+                }
 
                 this.currentRitualRecipeId = null;
             }
@@ -849,16 +852,12 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
 
     /**
      * Gets all ritual recipes from the recipe manager, filtering by type.
-     * In 26.1, getAllRecipesFor was removed; we must use getRecipes() and filter.
+     * Uses OccultismRecipeManager for both server and client-side access.
      */
     @SuppressWarnings("unchecked")
     private static List<RecipeHolder<RitualRecipe>> getAllRitualRecipes(Level level) {
-        if (level instanceof ServerLevel serverLevel) {
-            return serverLevel.recipeAccess().getRecipes().stream()
-                    .filter(r -> r.value().getType() == OccultismRecipes.RITUAL_TYPE.get())
-                    .map(r -> (RecipeHolder<RitualRecipe>) (RecipeHolder<?>) r)
-                    .toList();
-        }
-        return List.of();
+        return OccultismRecipeManager.get().getRecipesByType(OccultismRecipes.RITUAL_TYPE.get(), level).stream()
+                .map(r -> (RecipeHolder<RitualRecipe>) (RecipeHolder<?>) r)
+                .toList();
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/NetworkedBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/NetworkedBlockEntity.java
@@ -32,6 +32,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
+import org.jspecify.annotations.NonNull;
 
 public abstract class NetworkedBlockEntity extends BlockEntity {
 
@@ -57,13 +58,8 @@ public abstract class NetworkedBlockEntity extends BlockEntity {
     }
 
     @Override
-    public CompoundTag getUpdateTag(HolderLookup.Provider provider) {
-        //getUpdateTag still uses CompoundTag - we save our network data into it
-        var tag = super.getUpdateTag(provider);
-        //Note: this returns CompoundTag, not ValueOutput.
-        //The saveNetwork call here uses the old pattern - subclasses that override saveNetwork(ValueOutput)
-        //will have their data included via saveWithoutMetadata which is called by getUpdatePacket.
-        return tag;
+    public @NonNull CompoundTag getUpdateTag(HolderLookup.@NonNull Provider provider) {
+        return this.saveWithoutMetadata(provider);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/item/DummyTooltipItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/DummyTooltipItem.java
@@ -23,6 +23,7 @@
 package com.klikli_dev.occultism.common.item;
 
 import com.klikli_dev.occultism.common.blockentity.GoldenSacrificialBowlBlockEntity;
+import com.klikli_dev.occultism.crafting.recipe.OccultismRecipeManager;
 import com.klikli_dev.occultism.crafting.recipe.RitualRecipe;
 import com.klikli_dev.occultism.registry.OccultismRecipes;
 import net.minecraft.core.BlockPos;
@@ -50,10 +51,8 @@ public class DummyTooltipItem extends Item {
 
     public void performRitual(Level level, BlockPos pos, GoldenSacrificialBowlBlockEntity blockEntity,
                               @Nullable Player player, ItemStack activationItem) {
-        if (!(level instanceof ServerLevel serverLevel)) return;
-        var ritualRecipe = serverLevel.recipeAccess().getRecipes()
+        var ritualRecipe = OccultismRecipeManager.get().getRecipesByType(OccultismRecipes.RITUAL_TYPE.get(), level)
                 .stream()
-                .filter(r -> r.value().getType() == OccultismRecipes.RITUAL_TYPE.get())
                 .filter(r -> ((RitualRecipe) r.value()).getRitualDummy().getItem() == this)
                 .findFirst();
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/MultiBlockRitualSatchelItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/ritual_satchel/MultiBlockRitualSatchelItem.java
@@ -6,6 +6,7 @@ import com.klikli_dev.modonomicon.multiblock.matcher.DisplayOnlyMatcher;
 import com.klikli_dev.occultism.TranslationKeys;
 import com.klikli_dev.occultism.common.container.satchel.RitualSatchelContainer;
 import com.klikli_dev.occultism.common.container.satchel.RitualSatchelT2Container;
+import com.klikli_dev.occultism.crafting.recipe.OccultismRecipeManager;
 import com.klikli_dev.occultism.crafting.recipe.RitualRecipe;
 import com.klikli_dev.occultism.registry.OccultismBlocks;
 import com.klikli_dev.occultism.registry.OccultismRecipes;
@@ -68,7 +69,7 @@ public class MultiBlockRitualSatchelItem extends RitualSatchelItem {
     }
 
     protected InteractionResult collectPentacle(UseOnContext context) {
-        var pentacles = ((ServerLevel) context.getLevel()).recipeAccess().getRecipes().stream()
+        var pentacles = OccultismRecipeManager.get().getRecipesByType(OccultismRecipes.RITUAL_TYPE.get(), context.getLevel()).stream()
                 .filter(r -> r.value().getType() == OccultismRecipes.RITUAL_TYPE.get())
                 .map(r -> (RecipeHolder<RitualRecipe>) r)
                 //First deduplicate pentacles

--- a/src/main/java/com/klikli_dev/occultism/common/ritual/Ritual.java
+++ b/src/main/java/com/klikli_dev/occultism/common/ritual/Ritual.java
@@ -26,6 +26,7 @@ import com.google.common.base.Suppliers;
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.common.blockentity.GoldenSacrificialBowlBlockEntity;
 import com.klikli_dev.occultism.common.blockentity.SacrificialBowlBlockEntity;
+import com.klikli_dev.occultism.crafting.recipe.OccultismRecipeManager;
 import com.klikli_dev.occultism.crafting.recipe.RitualRecipe;
 import com.klikli_dev.occultism.crafting.recipe.conditionextension.ConditionWrapperFactory;
 import com.klikli_dev.occultism.crafting.recipe.conditionextension.RitualRecipeConditionContext;
@@ -142,14 +143,10 @@ public abstract class Ritual {
         if (this.recipeHolderSupplier == null) {
             this.recipeHolderSupplier =
                     Suppliers.memoize(() -> {
-                        if (level instanceof ServerLevel serverLevel) {
-                            return serverLevel.recipeAccess().getRecipes().stream()
-                                    .filter(r -> r.value().getType() == OccultismRecipes.RITUAL_TYPE.get())
-                                    .filter(r -> r.value() == this.getRecipe())
-                                    .map(r -> (RecipeHolder<RitualRecipe>) (RecipeHolder<?>) r)
-                                    .findFirst().orElse(null);
-                        }
-                        return null;
+                        return OccultismRecipeManager.get().getRecipesByType(OccultismRecipes.RITUAL_TYPE.get(), level).stream()
+                                .filter(r -> r.value() == this.getRecipe())
+                                .map(r -> (RecipeHolder<RitualRecipe>) (RecipeHolder<?>) r)
+                                .findFirst().orElse(null);
                     });
         }
         return this.recipeHolderSupplier.get();

--- a/src/main/java/com/klikli_dev/occultism/crafting/recipe/OccultismRecipeManager.java
+++ b/src/main/java/com/klikli_dev/occultism/crafting/recipe/OccultismRecipeManager.java
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2024 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.occultism.crafting.recipe;
+
+import com.klikli_dev.occultism.registry.OccultismRecipes;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.RecipeInput;
+import net.minecraft.world.item.crafting.RecipeMap;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.util.Lazy;
+import net.neoforged.neoforge.event.OnDatapackSyncEvent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class OccultismRecipeManager {
+    private static final OccultismRecipeManager INSTANCE = new OccultismRecipeManager();
+    private static final Lazy<List<RecipeType<?>>> SYNCED_RECIPE_TYPES = Lazy.of(() -> List.of(
+            OccultismRecipes.SPIRIT_TRADE_TYPE.get(),
+            OccultismRecipes.SPIRIT_FIRE_TYPE.get(),
+            OccultismRecipes.CRUSHING_TYPE.get(),
+            OccultismRecipes.CRYSTALLIZE_TYPE.get(),
+            OccultismRecipes.MINER_TYPE.get(),
+            OccultismRecipes.RITUAL_TYPE.get()
+    ));
+
+    private final Map<RecipeType<?>, Collection<RecipeHolder<?>>> clientRecipeCache = new ConcurrentHashMap<>();
+    private final Map<RecipeType<?>, Map<ResourceKey<Recipe<?>>, RecipeHolder<?>>> clientRecipeByKeyCache = new ConcurrentHashMap<>();
+    private volatile long recipeGeneration;
+
+    private OccultismRecipeManager() {
+    }
+
+    public static OccultismRecipeManager get() {
+        return INSTANCE;
+    }
+
+    public static OccultismRecipeManager getInstance() {
+        return INSTANCE;
+    }
+
+    private List<RecipeType<?>> syncedRecipeTypes() {
+        return SYNCED_RECIPE_TYPES.get();
+    }
+
+    public long getRecipeGeneration() {
+        return this.recipeGeneration;
+    }
+
+    public <C extends RecipeInput, T extends Recipe<C>> Collection<RecipeHolder<T>> getRecipesByType(RecipeType<T> type, Level level) {
+        if (level == null) {
+            return List.of();
+        }
+
+        if (level.isClientSide()) {
+            //noinspection unchecked
+            return (Collection<RecipeHolder<T>>) (Collection<?>) this.clientRecipeCache.getOrDefault(type, List.of());
+        }
+
+        return level.getServer().getRecipeManager().recipeMap().byType(type);
+    }
+
+    public <C extends RecipeInput, T extends Recipe<C>> Optional<RecipeHolder<T>> getRecipeFor(RecipeType<T> type, C input, Level level) {
+        return this.getRecipeFor(type, input, level, null);
+    }
+
+    public <C extends RecipeInput, T extends Recipe<C>> Optional<RecipeHolder<T>> getRecipeFor(RecipeType<T> type, C input, Level level, ResourceKey<Recipe<?>> lastRecipe) {
+        if (level == null) {
+            return Optional.empty();
+        }
+
+        if (lastRecipe != null) {
+            var cachedRecipe = this.getRecipeByKey(type, lastRecipe, level);
+            if (cachedRecipe.isPresent() && cachedRecipe.get().value().matches(input, level)) {
+                return cachedRecipe;
+            }
+        }
+
+        if (level.isClientSide()) {
+            return this.getRecipesByType(type, level).stream()
+                    .filter(recipe -> recipe.value().matches(input, level))
+                    .findFirst();
+        }
+
+        return level.getServer().getRecipeManager().getRecipeFor(type, input, level);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends Recipe<?>> Optional<RecipeHolder<T>> getRecipeByKey(RecipeType<T> type, ResourceKey<Recipe<?>> key, Level level) {
+        if (key == null || level == null) {
+            return Optional.empty();
+        }
+
+        if (level.isClientSide()) {
+            var typeMap = this.clientRecipeByKeyCache.get(type);
+            if (typeMap != null) {
+                return Optional.ofNullable((RecipeHolder<T>) typeMap.get(key));
+            }
+            return Optional.empty();
+        }
+
+        return level.getServer().getRecipeManager().byKey(key)
+                .filter(recipe -> recipe.value().getType() == type)
+                .map(recipe -> (RecipeHolder<T>) recipe);
+    }
+
+    public void onDatapackSync(OnDatapackSyncEvent event) {
+        this.recipeGeneration++;
+        this.syncedRecipeTypes().forEach(event::sendRecipes);
+    }
+
+    void clearClientCache() {
+        this.recipeGeneration++;
+        this.clientRecipeCache.clear();
+        this.clientRecipeByKeyCache.clear();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void storeClientRecipesUnchecked(RecipeMap recipeMap, RecipeType<?> type) {
+        this.storeClientRecipes(recipeMap, (RecipeType) type);
+    }
+
+    private <I extends RecipeInput, T extends Recipe<I>> void storeClientRecipes(RecipeMap recipeMap, RecipeType<T> type) {
+        this.storeClientRecipes(type, recipeMap.byType(type));
+    }
+
+    private <T extends Recipe<?>> void storeClientRecipes(RecipeType<T> type, Iterable<RecipeHolder<T>> recipes) {
+        var recipeList = new ArrayList<RecipeHolder<?>>();
+        var recipesByKey = new ConcurrentHashMap<ResourceKey<Recipe<?>>, RecipeHolder<?>>();
+
+        for (var recipe : recipes) {
+            recipeList.add(recipe);
+            recipesByKey.put(recipe.id(), recipe);
+        }
+
+        this.clientRecipeCache.put(type, List.copyOf(recipeList));
+        this.clientRecipeByKeyCache.put(type, recipesByKey);
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/crafting/recipe/OccultismRecipeManagerClient.java
+++ b/src/main/java/com/klikli_dev/occultism/crafting/recipe/OccultismRecipeManagerClient.java
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024 klikli-dev
+//
+// SPDX-License-Identifier: MIT
+
+package com.klikli_dev.occultism.crafting.recipe;
+
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.client.event.RecipesReceivedEvent;
+
+public final class OccultismRecipeManagerClient {
+    private OccultismRecipeManagerClient() {
+    }
+
+    public static void onRecipesReceived(RecipesReceivedEvent event) {
+        var manager = OccultismRecipeManager.get();
+        manager.clearClientCache();
+
+        for (var type : event.getRecipeTypes()) {
+            manager.storeClientRecipesUnchecked(event.getRecipeMap(), type);
+        }
+    }
+
+    public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
+        OccultismRecipeManager.get().clearClientCache();
+    }
+}

--- a/src/main/java/com/klikli_dev/occultism/handlers/ClientPlayerEventHandler.java
+++ b/src/main/java/com/klikli_dev/occultism/handlers/ClientPlayerEventHandler.java
@@ -24,7 +24,6 @@ package com.klikli_dev.occultism.handlers;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.client.gui.satchel.SatchelScreen;
-import com.klikli_dev.occultism.crafting.recipe.OccultismRecipeManagerClient;
 import com.klikli_dev.occultism.client.gui.storage.StorageControllerGui;
 import com.klikli_dev.occultism.client.gui.storage.StorageRemoteGui;
 import com.klikli_dev.occultism.network.Networking;
@@ -47,9 +46,7 @@ import net.minecraft.world.inventory.ChestMenu;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
-import net.neoforged.neoforge.client.event.RecipesReceivedEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 import net.neoforged.neoforge.event.PlayLevelSoundEvent;
 
@@ -173,16 +170,6 @@ public class ClientPlayerEventHandler {
             minecraft.player.closeContainer();
             event.setCanceled(true);
         }
-    }
-
-    @SubscribeEvent
-    public static void onRecipesReceived(RecipesReceivedEvent event) {
-        OccultismRecipeManagerClient.onRecipesReceived(event);
-    }
-
-    @SubscribeEvent
-    public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
-        OccultismRecipeManagerClient.onClientLogout(event);
     }
     //endregion Static Methods
 }

--- a/src/main/java/com/klikli_dev/occultism/handlers/ClientPlayerEventHandler.java
+++ b/src/main/java/com/klikli_dev/occultism/handlers/ClientPlayerEventHandler.java
@@ -24,6 +24,7 @@ package com.klikli_dev.occultism.handlers;
 
 import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.client.gui.satchel.SatchelScreen;
+import com.klikli_dev.occultism.crafting.recipe.OccultismRecipeManagerClient;
 import com.klikli_dev.occultism.client.gui.storage.StorageControllerGui;
 import com.klikli_dev.occultism.client.gui.storage.StorageRemoteGui;
 import com.klikli_dev.occultism.network.Networking;
@@ -46,7 +47,9 @@ import net.minecraft.world.inventory.ChestMenu;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
+import net.neoforged.neoforge.client.event.RecipesReceivedEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 import net.neoforged.neoforge.event.PlayLevelSoundEvent;
 
@@ -170,6 +173,16 @@ public class ClientPlayerEventHandler {
             minecraft.player.closeContainer();
             event.setCanceled(true);
         }
+    }
+
+    @SubscribeEvent
+    public static void onRecipesReceived(RecipesReceivedEvent event) {
+        OccultismRecipeManagerClient.onRecipesReceived(event);
+    }
+
+    @SubscribeEvent
+    public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
+        OccultismRecipeManagerClient.onClientLogout(event);
     }
     //endregion Static Methods
 }


### PR DESCRIPTION
## Summary
- Fix items not rendering at all due to server-client block entity sync issues
- Fix items/blocks in sacrificial bowl rendering at quarter size instead of half size
- Fix items rendering fullbright (unnaturally bright)

## Changes
- Change `ItemDisplayContext.GROUND` → `FIXED` in both SacrificialBowlRenderer and GoldenSacrificialBowlRenderer
- Change color tint `0xFFFFFFFF` → `0` so model uses default coloring instead of forced white

## Root Cause
The 1.21.1 renderer used `ItemDisplayContext.FIXED` which renders items at full size then applies 0.5f scale = 0.5x final. The 26.1.2 migration changed to `GROUND` which already applies 0.5x internally, resulting in 0.5f × 0.5x = 0.25x final (quarter size).

Also, the color tint parameter `0xFFFFFFFF` was forcing fullbright rendering via ARGB white override.

Closes #1558