### PR TITLE
fix: prevent NPE in SoulShardItem tooltip when entity type is null

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
@@ -26,7 +26,6 @@ import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.common.container.DimensionalBattlefieldContainer;
 import com.klikli_dev.occultism.common.entity.possessed.PossessedMob;
 import com.klikli_dev.occultism.registry.*;
-import com.klikli_dev.occultism.util.EntityUtil;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -56,6 +55,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.TypedEntityData;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.Level;
@@ -424,8 +424,12 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
     public void setStoredLivingEntity(ItemStack stack, ServerLevel level) {
         this.storedLivingEntity = null;
         if (!stack.isEmpty() && stack.has(DataComponents.ENTITY_DATA) && this.level != null) {
-            CompoundTag entityData = Objects.requireNonNull(stack.get(DataComponents.ENTITY_DATA)).copyTagWithoutId();
-            Entity tempEntity = EntityUtil.entityTypeFromNbt(entityData).create(this.level, EntitySpawnReason.MOB_SUMMONED);
+            // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
+            // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
+            TypedEntityData<?> typedEntityData = Objects.requireNonNull(stack.get(DataComponents.ENTITY_DATA));
+            @SuppressWarnings("unchecked")
+            EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
+            Entity tempEntity = entityType.create(this.level, EntitySpawnReason.MOB_SUMMONED);
             if (tempEntity instanceof LivingEntity livingEntity)
                 this.storedLivingEntity = livingEntity;
         }

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
@@ -426,9 +426,8 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
         if (!stack.isEmpty() && stack.has(DataComponents.ENTITY_DATA) && this.level != null) {
             // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
             // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
-            TypedEntityData<?> typedEntityData = Objects.requireNonNull(stack.get(DataComponents.ENTITY_DATA));
-            @SuppressWarnings("unchecked")
-            EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
+            var typedEntityData = Objects.requireNonNull(stack.get(DataComponents.ENTITY_DATA));
+            EntityType<?> entityType = typedEntityData.type();
             Entity tempEntity = entityType.create(this.level, EntitySpawnReason.MOB_SUMMONED);
             if (tempEntity instanceof LivingEntity livingEntity)
                 this.storedLivingEntity = livingEntity;

--- a/src/main/java/com/klikli_dev/occultism/common/item/spirit/BookOfCallingItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/spirit/BookOfCallingItem.java
@@ -186,7 +186,8 @@ public class BookOfCallingItem extends Item implements IHandleItemMode {
 
                 itemStack.remove(OccultismDataComponents.SPIRIT_ENTITY_DATA);
                 itemStack.set(DataComponents.RARITY, Rarity.COMMON);
-                player.inventoryMenu.broadcastChanges();
+                if (player != null)
+                    player.inventoryMenu.broadcastChanges();
             }
         } else {
             //if there are no entities stored, we can either open the ui or perform the action

--- a/src/main/java/com/klikli_dev/occultism/common/item/spirit/BookOfCallingItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/spirit/BookOfCallingItem.java
@@ -135,11 +135,20 @@ public class BookOfCallingItem extends Item implements IHandleItemMode {
         Level world = context.getLevel();
         Direction facing = context.getClickedFace();
         BlockPos pos = context.getClickedPos();
-        CompoundTag entityData = ItemNBTUtil.getSpiritEntityData(itemStack);
-        if (entityData != null) {
+        var spiritEntityData = ItemNBTUtil.getSpiritEntityDataComponent(itemStack);
+        if (spiritEntityData != null) {
             //whenever we have an entity stored we can do nothing but release it
             if (!world.isClientSide()) {
-                EntityType type = EntityUtil.entityTypeFromNbt(entityData);
+                if (spiritEntityData.contains(OccultismDataComponents.INVALID_SPIRIT_ENTITY_DATA_MARKER)) {
+                    itemStack.remove(OccultismDataComponents.SPIRIT_ENTITY_DATA);
+                    itemStack.set(DataComponents.RARITY, Rarity.COMMON);
+                    if (player != null)
+                        player.inventoryMenu.broadcastChanges();
+                    return InteractionResult.FAIL;
+                }
+
+                EntityType<?> type = spiritEntityData.type();
+                CompoundTag entityData = spiritEntityData.copyTagWithoutId();
 
                 facing = facing == null ? Direction.UP : facing;
 
@@ -151,11 +160,14 @@ public class BookOfCallingItem extends Item implements IHandleItemMode {
                 //remove position from tag to allow the entity to spawn where it should be
                 entityData.remove("Pos");
 
-                //type.spawn uses the sub-tag EntityTag
-                CompoundTag wrapper = new CompoundTag();
-                wrapper.put("EntityTag", entityData);
+                if (!(type.create(world, EntitySpawnReason.LOAD) instanceof SpiritEntity entity)) {
+                    itemStack.remove(OccultismDataComponents.SPIRIT_ENTITY_DATA);
+                    itemStack.set(DataComponents.RARITY, Rarity.COMMON);
+                    if (player != null)
+                        player.inventoryMenu.broadcastChanges();
+                    return InteractionResult.FAIL;
+                }
 
-                SpiritEntity entity = (SpiritEntity) type.create(world, EntitySpawnReason.LOAD);
                 try (ProblemReporter.ScopedCollector reporter = new ProblemReporter.ScopedCollector(entity.problemPath(), LOGGER)) {
                     entity.load(TagValueInput.create(reporter, entity.registryAccess(), entityData));
                 }
@@ -171,8 +183,6 @@ public class BookOfCallingItem extends Item implements IHandleItemMode {
 
                 //refresh item nbt
                 ItemNBTUtil.updateItemNBTFromEntity(itemStack, entity);
-
-                world.addFreshEntity(entity);
 
                 itemStack.remove(OccultismDataComponents.SPIRIT_ENTITY_DATA);
                 itemStack.set(DataComponents.RARITY, Rarity.COMMON);
@@ -288,11 +298,8 @@ public class BookOfCallingItem extends Item implements IHandleItemMode {
             targetSpirit.saveWithoutId(output);
             entityData = output.buildResult();
         }
-        var id = targetSpirit.getEncodeId();
-        if(id != null)
-            entityData.putString("id", id);
 
-        ItemNBTUtil.setSpiritEntityData(stack, entityData);
+        ItemNBTUtil.setSpiritEntityData(stack, targetSpirit.getType(), entityData);
         ItemNBTUtil.setSpiritEntityUUID(stack, targetSpirit.getUUID());
         ItemNBTUtil.setBoundSpiritName(stack, targetSpirit.getName().getString());
         //show player swing anim

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/MagicLampItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/MagicLampItem.java
@@ -75,10 +75,9 @@ public class MagicLampItem extends Item {
             if (player != null && !level.isClientSide()) {
                 // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
                 // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
-                TypedEntityData<?> typedEntityData = Objects.requireNonNull(itemStack.get(DataComponents.ENTITY_DATA));
+                var typedEntityData = Objects.requireNonNull(itemStack.get(DataComponents.ENTITY_DATA));
                 CompoundTag entityData = typedEntityData.copyTagWithoutId();
-                @SuppressWarnings("unchecked")
-                EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
+                EntityType<?> entityType = typedEntityData.type();
                 itemStack.remove(DataComponents.ENTITY_DATA);
                 BlockPos spawnPos = pos.immutable();
                 if (!level.getBlockState(spawnPos).getCollisionShape(level, spawnPos).isEmpty())

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/MagicLampItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/MagicLampItem.java
@@ -23,7 +23,6 @@
 package com.klikli_dev.occultism.common.item.tool;
 
 import com.klikli_dev.occultism.common.entity.spirit.SpiritEntity;
-import com.klikli_dev.occultism.util.EntityUtil;
 import com.klikli_dev.occultism.util.ItemNBTUtil;
 import com.klikli_dev.occultism.util.TextUtil;
 import net.minecraft.core.BlockPos;
@@ -74,14 +73,18 @@ public class MagicLampItem extends Item {
         BlockPos pos = context.getClickedPos();
         if (itemStack.has(DataComponents.ENTITY_DATA)) {
             if (player != null && !level.isClientSide()) {
-                CompoundTag entityData = Objects.requireNonNull(itemStack.get(DataComponents.ENTITY_DATA)).getUnsafe().copy();
+                // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
+                // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
+                TypedEntityData<?> typedEntityData = Objects.requireNonNull(itemStack.get(DataComponents.ENTITY_DATA));
+                CompoundTag entityData = typedEntityData.copyTagWithoutId();
+                @SuppressWarnings("unchecked")
+                EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
                 itemStack.remove(DataComponents.ENTITY_DATA);
-                EntityType<?> type = EntityUtil.entityTypeFromNbt(entityData);
                 BlockPos spawnPos = pos.immutable();
                 if (!level.getBlockState(spawnPos).getCollisionShape(level, spawnPos).isEmpty())
                     spawnPos = spawnPos.relative(facing);
                 entityData.remove("Pos");
-                Entity entity = type.create(level, EntitySpawnReason.LOAD);
+                Entity entity = entityType.create(level, EntitySpawnReason.LOAD);
                 assert entity != null;
                 entity.load(TagValueInput.create(ProblemReporter.DISCARDING, level.registryAccess(), entityData));
                 entity.snapTo(spawnPos.getX() + 0.5, spawnPos.getY(), spawnPos.getZ() + 0.5, 0, 0);
@@ -138,7 +141,7 @@ public class MagicLampItem extends Item {
     protected EntityType<?> getType(ItemStack pStack) {
         var data = pStack.get(DataComponents.ENTITY_DATA);
         if (data == null) return null;
-        return EntityUtil.entityTypeFromNbt(data.getUnsafe());
+        return data.type();
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulGemItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulGemItem.java
@@ -24,7 +24,6 @@ package com.klikli_dev.occultism.common.item.tool;
 
 import com.klikli_dev.occultism.registry.OccultismItems;
 import com.klikli_dev.occultism.registry.OccultismTags;
-import com.klikli_dev.occultism.util.EntityUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponents;
@@ -76,10 +75,13 @@ public class SoulGemItem extends Item {
         if (itemStack.has(DataComponents.ENTITY_DATA)) {
             //whenever we have an entity stored we can do nothing but release it
             if (!level.isClientSide()) {
-                CompoundTag entityData = itemStack.get(DataComponents.ENTITY_DATA).getUnsafe();
+                // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
+                // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
+                TypedEntityData<?> typedEntityData = itemStack.get(DataComponents.ENTITY_DATA);
+                CompoundTag entityData = typedEntityData.copyTagWithoutId();
+                @SuppressWarnings("unchecked")
+                EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
                 itemStack.remove(DataComponents.ENTITY_DATA); //delete entity from item right away to avoid duplicate in case of unexpected error
-
-                EntityType<?> type = EntityUtil.entityTypeFromNbt(entityData);
 
                 facing = facing == null ? Direction.UP : facing;
 
@@ -91,7 +93,7 @@ public class SoulGemItem extends Item {
                 //remove position from tag to allow the entity to spawn where it should be
                 entityData.remove("Pos");
 
-                Entity entity = type.create(level, EntitySpawnReason.MOB_SUMMONED);
+                Entity entity = entityType.create(level, EntitySpawnReason.MOB_SUMMONED);
                 entity.load(TagValueInput.create(ProblemReporter.DISCARDING, entity.registryAccess(), entityData));
                 entity.snapTo(spawnPos.getX() + 0.5, spawnPos.getY(), spawnPos.getZ() + 0.5, 0, 0);
                 float yaw = player.getYHeadRot() + 180;
@@ -158,17 +160,11 @@ public class SoulGemItem extends Item {
             return InteractionResult.FAIL;
         }
 
-        var entityData = new CompoundTag();
-        var id = target.getEncodeId();
-        if(id != null)
-            entityData.putString("id", id);
         var output = TagValueOutput.createWithoutContext(ProblemReporter.DISCARDING);
         target.saveWithoutId(output);
-        entityData = output.buildResult();
-        if(id != null)
-            entityData.putString("id", id);
+        var entityData = output.buildResult();
 
-        //serialize entity
+        //serialize entity - TypedEntityData stores the type directly, so we don't need the "id" in the NBT
         stack.set(DataComponents.ENTITY_DATA, TypedEntityData.of(target.getType(), entityData));
         //show player swing anim
         player.swing(hand);

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulGemItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulGemItem.java
@@ -77,10 +77,9 @@ public class SoulGemItem extends Item {
             if (!level.isClientSide()) {
                 // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
                 // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
-                TypedEntityData<?> typedEntityData = itemStack.get(DataComponents.ENTITY_DATA);
+                var typedEntityData = itemStack.get(DataComponents.ENTITY_DATA);
                 CompoundTag entityData = typedEntityData.copyTagWithoutId();
-                @SuppressWarnings("unchecked")
-                EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
+                EntityType<?> entityType = typedEntityData.type();
                 itemStack.remove(DataComponents.ENTITY_DATA); //delete entity from item right away to avoid duplicate in case of unexpected error
 
                 facing = facing == null ? Direction.UP : facing;

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulShardItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulShardItem.java
@@ -23,7 +23,6 @@
 package com.klikli_dev.occultism.common.item.tool;
 
 import com.klikli_dev.occultism.registry.OccultismDataComponents;
-import com.klikli_dev.occultism.util.EntityUtil;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -39,6 +38,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
+import net.minecraft.world.item.component.TypedEntityData;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.LootTable;
@@ -60,10 +60,10 @@ public class SoulShardItem extends Item {
     public void appendHoverText(ItemStack pStack, Item.TooltipContext pContext, TooltipDisplay pTooltipDisplay, Consumer<Component> pTooltipAdder, TooltipFlag pTooltipFlag) {
         super.appendHoverText(pStack, pContext, pTooltipDisplay, pTooltipAdder, pTooltipFlag);
         if (pStack.has(DataComponents.ENTITY_DATA)) {
-            EntityType<?> type = EntityUtil.entityTypeFromNbt(pStack.get(DataComponents.ENTITY_DATA).getUnsafe());
-            if (type != null) {
-                pTooltipAdder.accept(Component.translatable(this.getDescriptionId() + ".tooltip_filled", type.getDescription()));
-            }
+            // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
+            // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
+            EntityType<?> type = pStack.get(DataComponents.ENTITY_DATA).type();
+            pTooltipAdder.accept(Component.translatable(this.getDescriptionId() + ".tooltip_filled", type.getDescription()));
         } else {
             pTooltipAdder.accept(Component.translatable(this.getDescriptionId() + ".tooltip_empty"));
         }
@@ -76,8 +76,13 @@ public class SoulShardItem extends Item {
             return InteractionResult.PASS;
 
         if (level instanceof ServerLevel serverLevel) {
-            CompoundTag entityData = Objects.requireNonNull(stack.get(DataComponents.ENTITY_DATA)).copyTagWithoutId();
-            Entity tempEntity = EntityUtil.entityTypeFromNbt(entityData).create(level, EntitySpawnReason.MOB_SUMMONED);
+            // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
+            // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
+            TypedEntityData<?> typedEntityData = Objects.requireNonNull(stack.get(DataComponents.ENTITY_DATA));
+            CompoundTag entityData = typedEntityData.copyTagWithoutId();
+            @SuppressWarnings("unchecked")
+            EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
+            Entity tempEntity = entityType.create(level, EntitySpawnReason.MOB_SUMMONED);
             LivingEntity mob = tempEntity instanceof LivingEntity living ? living : null;
 
             if (mob != null) {

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulShardItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulShardItem.java
@@ -78,10 +78,9 @@ public class SoulShardItem extends Item {
         if (level instanceof ServerLevel serverLevel) {
             // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
             // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
-            TypedEntityData<?> typedEntityData = Objects.requireNonNull(stack.get(DataComponents.ENTITY_DATA));
+            var typedEntityData = Objects.requireNonNull(stack.get(DataComponents.ENTITY_DATA));
             CompoundTag entityData = typedEntityData.copyTagWithoutId();
-            @SuppressWarnings("unchecked")
-            EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
+            EntityType<?> entityType = typedEntityData.type();
             Entity tempEntity = entityType.create(level, EntitySpawnReason.MOB_SUMMONED);
             LivingEntity mob = tempEntity instanceof LivingEntity living ? living : null;
 

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulShardItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/SoulShardItem.java
@@ -61,7 +61,9 @@ public class SoulShardItem extends Item {
         super.appendHoverText(pStack, pContext, pTooltipDisplay, pTooltipAdder, pTooltipFlag);
         if (pStack.has(DataComponents.ENTITY_DATA)) {
             EntityType<?> type = EntityUtil.entityTypeFromNbt(pStack.get(DataComponents.ENTITY_DATA).getUnsafe());
-            pTooltipAdder.accept(Component.translatable(this.getDescriptionId() + ".tooltip_filled", type.getDescription()));
+            if (type != null) {
+                pTooltipAdder.accept(Component.translatable(this.getDescriptionId() + ".tooltip_filled", type.getDescription()));
+            }
         } else {
             pTooltipAdder.accept(Component.translatable(this.getDescriptionId() + ".tooltip_empty"));
         }

--- a/src/main/java/com/klikli_dev/occultism/common/ritual/ResurrectFamiliarRitual.java
+++ b/src/main/java/com/klikli_dev/occultism/common/ritual/ResurrectFamiliarRitual.java
@@ -76,10 +76,9 @@ public class ResurrectFamiliarRitual extends SummonRitual {
         if (shard.has(DataComponents.ENTITY_DATA)) {
             // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
             // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
-            TypedEntityData<?> typedEntityData = shard.get(DataComponents.ENTITY_DATA);
+            var typedEntityData = shard.get(DataComponents.ENTITY_DATA);
             var entityData = typedEntityData.copyTagWithoutId();
-            @SuppressWarnings("unchecked")
-            EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
+            EntityType<?> entityType = typedEntityData.type();
 
             BlockPos spawnPos = goldenBowlPosition;
 

--- a/src/main/java/com/klikli_dev/occultism/common/ritual/ResurrectFamiliarRitual.java
+++ b/src/main/java/com/klikli_dev/occultism/common/ritual/ResurrectFamiliarRitual.java
@@ -29,7 +29,6 @@ import com.klikli_dev.occultism.crafting.recipe.RitualRecipe;
 import com.klikli_dev.occultism.registry.OccultismAdvancements;
 import com.klikli_dev.occultism.registry.OccultismItems;
 import com.klikli_dev.occultism.registry.OccultismSounds;
-import com.klikli_dev.occultism.util.EntityUtil;
 import com.klikli_dev.occultism.util.ItemNBTUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
@@ -42,7 +41,9 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.TypedEntityData;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.TagValueInput;
 import net.minecraft.world.phys.Vec3;
@@ -73,9 +74,12 @@ public class ResurrectFamiliarRitual extends SummonRitual {
 
         //copied and modified from soul gem item
         if (shard.has(DataComponents.ENTITY_DATA)) {
-            //whenever we have an entity stored we can do nothing but release it
-            var entityData = shard.get(DataComponents.ENTITY_DATA).getUnsafe();
-            var type = EntityUtil.entityTypeFromNbt(entityData);
+            // Get entity type directly from TypedEntityData - the "id" field is stripped from the NBT
+            // by TypedEntityData.of() since the type is already stored in the TypedEntityData itself
+            TypedEntityData<?> typedEntityData = shard.get(DataComponents.ENTITY_DATA);
+            var entityData = typedEntityData.copyTagWithoutId();
+            @SuppressWarnings("unchecked")
+            EntityType<Entity> entityType = (EntityType<Entity>) typedEntityData.type();
 
             BlockPos spawnPos = goldenBowlPosition;
 
@@ -86,7 +90,7 @@ public class ResurrectFamiliarRitual extends SummonRitual {
             CompoundTag wrapper = new CompoundTag();
             wrapper.put("EntityTag", entityData);
 
-            Entity entity = type.create(level, EntitySpawnReason.MOB_SUMMONED);
+            Entity entity = entityType.create(level, EntitySpawnReason.MOB_SUMMONED);
             entity.load(TagValueInput.create(ProblemReporter.DISCARDING, entity.registryAccess(), entityData));
             entity.snapTo(spawnPos.getX() + 0.5, spawnPos.getY() + 1, spawnPos.getZ() + 0.5, 0, 0);
             entity.setDeltaMovement(Vec3.ZERO);

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
@@ -4,18 +4,26 @@ import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.api.common.data.*;
 import com.klikli_dev.occultism.util.OccultismExtraCodecs;
 import com.klikli_dev.occultism.util.OccultismExtraStreamCodecs;
+import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.item.component.TypedEntityData;
 import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -24,6 +32,7 @@ import java.util.UUID;
 
 public class OccultismDataComponents {
     public static final DeferredRegister.DataComponents DATA_COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, Occultism.MODID);
+    public static final String INVALID_SPIRIT_ENTITY_DATA_MARKER = "occultism_invalid_spirit_entity_data";
     private static final StreamCodec<RegistryFriendlyByteBuf, CustomData> STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC = new StreamCodec<>() {
         @Override
         public CustomData decode(RegistryFriendlyByteBuf buffer) {
@@ -210,9 +219,43 @@ public class OccultismDataComponents {
             .cacheEncoding()
     );
 
-    public static final DeferredHolder<DataComponentType<?>, DataComponentType<CustomData>> SPIRIT_ENTITY_DATA = DATA_COMPONENTS.registerComponentType("spirit_entity_data", builder -> builder
-            .persistent(CustomData.CODEC)
-            .networkSynchronized(CustomData.STREAM_CODEC)
+    private static final Codec<TypedEntityData<EntityType<?>>> STRICT_SPIRIT_ENTITY_DATA_CODEC = TypedEntityData.codec(EntityType.CODEC);
+    private static final Codec<TypedEntityData<EntityType<?>>> SPIRIT_ENTITY_DATA_CODEC = new Codec<>() {
+        @Override
+        public <T> DataResult<Pair<TypedEntityData<EntityType<?>>, T>> decode(DynamicOps<T> ops, T input) {
+            DataResult<Pair<TypedEntityData<EntityType<?>>, T>> strictResult = STRICT_SPIRIT_ENTITY_DATA_CODEC.decode(ops, input);
+            if (strictResult.result().isPresent()) {
+                return strictResult;
+            }
+
+            return CustomData.CODEC.decode(ops, input)
+                    .map(pair -> Pair.of(decodeLegacySpiritEntityData(pair.getFirst().copyTag()), pair.getSecond()));
+        }
+
+        @Override
+        public <T> DataResult<T> encode(TypedEntityData<EntityType<?>> input, DynamicOps<T> ops, T prefix) {
+            return STRICT_SPIRIT_ENTITY_DATA_CODEC.encode(input, ops, prefix);
+        }
+    };
+
+    private static TypedEntityData<EntityType<?>> decodeLegacySpiritEntityData(CompoundTag entityData) {
+        CompoundTag tagWithoutType = entityData.copy();
+        Tag typeTag = tagWithoutType.remove("id");
+        if (typeTag != null) {
+            var parsedType = EntityType.CODEC.parse(NbtOps.INSTANCE, typeTag).result();
+            if (parsedType.isPresent()) {
+                return TypedEntityData.of(parsedType.get(), tagWithoutType);
+            }
+        }
+
+        CompoundTag invalidData = tagWithoutType.copy();
+        invalidData.putBoolean(INVALID_SPIRIT_ENTITY_DATA_MARKER, true);
+        return TypedEntityData.of(EntityType.PIG, invalidData);
+    }
+
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<TypedEntityData<EntityType<?>>>> SPIRIT_ENTITY_DATA = DATA_COMPONENTS.registerComponentType("spirit_entity_data", builder -> builder
+            .persistent(SPIRIT_ENTITY_DATA_CODEC)
+            .networkSynchronized(TypedEntityData.streamCodec(EntityType.STREAM_CODEC))
             .cacheEncoding()
     );
 

--- a/src/main/java/com/klikli_dev/occultism/util/ItemNBTUtil.java
+++ b/src/main/java/com/klikli_dev/occultism/util/ItemNBTUtil.java
@@ -31,8 +31,10 @@ import com.klikli_dev.occultism.registry.OccultismDataComponents;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.item.component.TypedEntityData;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -232,15 +234,22 @@ public class ItemNBTUtil {
         return stack.getOrDefault(OccultismDataComponents.SPIRIT_DEAD, false);
     }
 
-    public static CompoundTag getSpiritEntityData(ItemStack stack) {
-        if (!stack.has(OccultismDataComponents.SPIRIT_ENTITY_DATA))
-            return null;
-
-        return stack.get(OccultismDataComponents.SPIRIT_ENTITY_DATA).copyTag();
+    public static @Nullable TypedEntityData<EntityType<?>> getSpiritEntityDataComponent(ItemStack stack) {
+        return stack.get(OccultismDataComponents.SPIRIT_ENTITY_DATA);
     }
 
-    public static void setSpiritEntityData(ItemStack stack, CompoundTag entityData) {
-        stack.set(OccultismDataComponents.SPIRIT_ENTITY_DATA, CustomData.of(entityData));
+    public static @Nullable EntityType<?> getSpiritEntityType(ItemStack stack) {
+        var entityData = getSpiritEntityDataComponent(stack);
+        return entityData == null ? null : entityData.type();
+    }
+
+    public static @Nullable CompoundTag getSpiritEntityData(ItemStack stack) {
+        var entityData = getSpiritEntityDataComponent(stack);
+        return entityData == null ? null : entityData.copyTagWithoutId();
+    }
+
+    public static void setSpiritEntityData(ItemStack stack, EntityType<?> entityType, CompoundTag entityData) {
+        stack.set(OccultismDataComponents.SPIRIT_ENTITY_DATA, TypedEntityData.of(entityType, entityData));
     }
 
     public static Optional<SpiritEntity> getSpiritEntity(ItemStack itemStack) {


### PR DESCRIPTION
## Summary
Fixed entity-item type handling by using `TypedEntityData.type()` instead of reparsing stripped NBT, and migrated Book of Calling spirit storage to typed entity data as well.

## Root Cause
`TypedEntityData.of()` intentionally strips the `id` key from stored NBT because the entity type is stored separately in the typed wrapper. Several code paths were still trying to recover the type from raw NBT, which could return null and crash.

## Included Fixes
### Typed entity handling fixes
- `SoulShardItem`
- `SoulGemItem`
- `MagicLampItem`
- `ResurrectFamiliarRitual`
- `DimensionalBattlefieldBlockEntity`

These now use `TypedEntityData.type()` directly instead of `EntityUtil.entityTypeFromNbt()`.

### Book of Calling migration
- Migrated `occultism:spirit_entity_data` from `CustomData` to `TypedEntityData<EntityType<?>>`
- Updated `ItemNBTUtil` helpers and `BookOfCallingItem` capture/release logic to use typed entity storage
- Removed the duplicate `world.addFreshEntity(entity)` call in `BookOfCallingItem.useOn()`

## Invalid existing items
Old or malformed player-created Book of Calling items should not crash on deserialization:
- the new persistent codec accepts legacy spirit payloads
- if the stored type is missing/invalid, the item is decoded into a harmless invalid marker state
- `BookOfCallingItem.useOn()` detects that marker, clears the stored spirit payload, resets rarity, and fails cleanly instead of spawning or crashing

## Validation
- `./gradlew.bat compileJava`