### PR TITLE
Restore third eye overlay and add 26.1.2 follow-up fixes

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/Occultism.java
+++ b/src/main/java/com/klikli_dev/occultism/Occultism.java
@@ -124,8 +124,10 @@ public class Occultism {
         if (FMLEnvironment.getDist() == Dist.CLIENT) {
             NeoForge.EVENT_BUS.addListener(OccultismRecipeManagerClient::onRecipesReceived);
             NeoForge.EVENT_BUS.addListener(OccultismRecipeManagerClient::onClientLogout);
+            modEventBus.addListener(ClientSetupEventHandler::onClientSetup);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterMenuScreens);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterClientExtensions);
+            modEventBus.addListener(ClientSetupEventHandler::onRegisterGuiOverlays);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterRenderPipelines);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterConditionalItemModelProperties);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterRangeSelectItemModelProperties);

--- a/src/main/java/com/klikli_dev/occultism/Occultism.java
+++ b/src/main/java/com/klikli_dev/occultism/Occultism.java
@@ -124,10 +124,8 @@ public class Occultism {
         if (FMLEnvironment.getDist() == Dist.CLIENT) {
             NeoForge.EVENT_BUS.addListener(OccultismRecipeManagerClient::onRecipesReceived);
             NeoForge.EVENT_BUS.addListener(OccultismRecipeManagerClient::onClientLogout);
-            modEventBus.addListener(ClientSetupEventHandler::onClientSetup);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterMenuScreens);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterClientExtensions);
-            modEventBus.addListener(ClientSetupEventHandler::onRegisterGuiOverlays);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterRenderPipelines);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterConditionalItemModelProperties);
             modEventBus.addListener(ClientSetupEventHandler::onRegisterRangeSelectItemModelProperties);

--- a/src/main/java/com/klikli_dev/occultism/client/render/ThirdEyeEffectRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/ThirdEyeEffectRenderer.java
@@ -27,8 +27,10 @@ import com.klikli_dev.occultism.api.common.data.OtherworldBlockTier;
 import com.klikli_dev.occultism.common.block.otherworld.IOtherworldBlock;
 import com.klikli_dev.occultism.registry.OccultismEffects;
 import com.klikli_dev.occultism.util.CuriosUtil;
-import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Player;
@@ -36,13 +38,14 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.client.gui.GuiLayer;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent.Post;
 
 import java.util.HashSet;
 import java.util.Set;
 
-public class ThirdEyeEffectRenderer {
+public class ThirdEyeEffectRenderer implements GuiLayer {
 
     public static final int MAX_THIRD_EYE_DISTANCE = 10;
     public static final Identifier THIRD_EYE_TEXTURE = Identifier.fromNamespaceAndPath(Occultism.MODID,
@@ -61,8 +64,21 @@ public class ThirdEyeEffectRenderer {
         }
     }
 
-    public void renderOverlay(PoseStack pose) {
-        // RenderSystem overlay rendering removed in 26.1 - stubbed out
+    @Override
+    public void render(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker) {
+        var minecraft = Minecraft.getInstance();
+        if (minecraft.player == null || minecraft.options.hideGui) {
+            return;
+        }
+
+        if (this.gogglesActiveLastTick || this.thirdEyeActiveLastTick) {
+            this.renderOverlay(guiGraphics);
+        }
+    }
+
+    public void renderOverlay(GuiGraphicsExtractor guiGraphics) {
+        guiGraphics.blit(RenderPipelines.GUI_TEXTURED, THIRD_EYE_TEXTURE, 0, 0, 0.0f, 0.0f,
+                guiGraphics.guiWidth(), guiGraphics.guiHeight(), 256, 256);
     }
 
     /**

--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/FarmerJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/FarmerJob.java
@@ -57,12 +57,11 @@ public class FarmerJob extends SpiritJob {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public List<SensorType<? extends Sensor<SpiritEntity>>> getSensorTypes() {
         return ImmutableList.of(
-                (SensorType<? extends Sensor<SpiritEntity>>) OccultismSensors.NEAREST_CROP.get(),
-                (SensorType<? extends Sensor<SpiritEntity>>) OccultismSensors.NEAREST_JOB_ITEM.get(),
-                (SensorType<? extends Sensor<SpiritEntity>>) OccultismSensors.UNREACHABLE_CROP_WALK_TARGET.get()
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.NEAREST_CROP.get(),
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.NEAREST_JOB_ITEM.get(),
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.UNREACHABLE_CROP_WALK_TARGET.get()
         );
     }
 

--- a/src/main/java/com/klikli_dev/occultism/common/entity/job/LumberjackJob.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/job/LumberjackJob.java
@@ -58,12 +58,11 @@ public class LumberjackJob extends SpiritJob {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public List<SensorType<? extends Sensor<SpiritEntity>>> getSensorTypes() {
         return ImmutableList.of(
-                (SensorType<? extends Sensor<SpiritEntity>>) OccultismSensors.NEAREST_TREE.get(),
-                (SensorType<? extends Sensor<SpiritEntity>>) OccultismSensors.NEAREST_JOB_ITEM.get(),
-                (SensorType<? extends Sensor<SpiritEntity>>) OccultismSensors.UNREACHABLE_TREE_WALK_TARGET.get()
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.NEAREST_TREE.get(),
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.NEAREST_JOB_ITEM.get(),
+                (SensorType<? extends Sensor<SpiritEntity>>) (SensorType<?>) OccultismSensors.UNREACHABLE_TREE_WALK_TARGET.get()
         );
     }
 

--- a/src/main/java/com/klikli_dev/occultism/handlers/ClientSetupEventHandler.java
+++ b/src/main/java/com/klikli_dev/occultism/handlers/ClientSetupEventHandler.java
@@ -311,14 +311,7 @@ public class ClientSetupEventHandler {
 
     @SubscribeEvent
     public static void onRegisterGuiOverlays(RegisterGuiLayersEvent event) {
-        // TODO (1.21 -> 26.1): The GUI overlay/render pipeline API changed in Minecraft 26.1.
-        // The original overlay logic using RenderSystem and PoseStack is no longer valid.
-        // Disable the overlays until they are ported to the new GuiGraphicsExtractor / RenderPipeline system.
-        // event.registerAboveAll(Identifier.fromNamespaceAndPath(Occultism.MODID, "third_eye"), (guiGraphics, partialTick) -> {
-        //     if (Occultism.THIRD_EYE_EFFECT_RENDERER.gogglesActiveLastTick || Occultism.THIRD_EYE_EFFECT_RENDERER.thirdEyeActiveLastTick) {
-        //         // Port overlay rendering to GuiGraphicsExtractor / RenderPipelines
-        //     }
-        // });
+        event.registerAboveAll(Identifier.fromNamespaceAndPath(Occultism.MODID, "third_eye"), Occultism.THIRD_EYE_EFFECT_RENDERER);
         // event.registerAbove(VanillaGuiLayers.HOTBAR, Identifier.fromNamespaceAndPath("occultism", "golden_sacrificial_bow_hud"), GoldenSacrificialBowlHUD.get());
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismFoods.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismFoods.java
@@ -41,6 +41,7 @@ public class OccultismFoods {
     public static final Consumable DATURA_CONSUMABLE = Consumable.builder()
             .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(OccultismEffects.THIRD_EYE, 15 * 20, 1), 0.7f))
             .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.HUNGER, 15 * 20, 1), 1.0f))
+            .onConsume(new ApplyStatusEffectsConsumeEffect(new MobEffectInstance(MobEffects.NAUSEA, 15 * 20, 1), 0.3f))
             .build();
 
     public static final Lazy<FoodProperties> DEMONS_DREAM_ESSENCE = Lazy.of(


### PR DESCRIPTION
## Summary
- restore the third-eye fullscreen overlay for 26.1.2 by porting it to the GuiLayer/RegisterGuiLayersEvent path
- fix the duplicate third-eye overlay registration crash, improve spirit job sensor type safety, and add nausea as an extra datura side effect
- keep the branch validated with `./gradlew.bat compileJava`