### PR TITLE
fix: stop syncing storage controller contents in entity data

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismDataComponents.java
@@ -24,7 +24,16 @@ import java.util.UUID;
 
 public class OccultismDataComponents {
     public static final DeferredRegister.DataComponents DATA_COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, Occultism.MODID);
-    private static final StreamCodec<RegistryFriendlyByteBuf, CustomData> STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC = StreamCodec.unit(CustomData.EMPTY);
+    private static final StreamCodec<RegistryFriendlyByteBuf, CustomData> STORAGE_CONTROLLER_CONTENTS_STREAM_CODEC = new StreamCodec<>() {
+        @Override
+        public CustomData decode(RegistryFriendlyByteBuf buffer) {
+            return CustomData.EMPTY;
+        }
+
+        @Override
+        public void encode(RegistryFriendlyByteBuf buffer, CustomData value) {
+        }
+    };
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> MAX_MINING_TIME = DATA_COMPONENTS.registerComponentType("max_mining_time", builder -> builder
             .persistent(Codec.INT)


### PR DESCRIPTION
## Summary
- replace the storage controller contents network stream codec with a no-op codec so dropped storage actuators no longer try to encode persisted contents into entity data sync
- preserve persistent storage controller contents on dropped items while matching the upstream oversized-sync fix behavior
- verify the branch with `./gradlew.bat compileJava`