### PR TITLE
fix: wandering trader ritual render crash

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/client/model/entity/WonderingTraderModel.java
+++ b/src/main/java/com/klikli_dev/occultism/client/model/entity/WonderingTraderModel.java
@@ -37,9 +37,5 @@ public class WonderingTraderModel extends DefaultedGeoModel<WonderingTraderEntit
     protected String subtype() {
         return "entity";
     }
-
-    // TODO: Implement bone animations (head rotation, common/other bone visibility)
-    //       via the renderer's addRenderData or a GeckoLib 26.1-compatible override point.
-    //       The previous setCustomAnimations approach is no longer supported in GeckoLib 26.1.
 }
 

--- a/src/main/java/com/klikli_dev/occultism/client/render/entity/WonderingTraderRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/entity/WonderingTraderRenderer.java
@@ -22,6 +22,9 @@
 
 package com.klikli_dev.occultism.client.render.entity;
 
+import com.geckolib.cache.model.GeoBone;
+import com.geckolib.renderer.base.BoneSnapshots;
+import com.geckolib.renderer.base.RenderPassInfo;
 import com.klikli_dev.occultism.client.model.entity.WonderingTraderModel;
 import com.klikli_dev.occultism.client.render.entity.glowlayer.ConditionalGlowingGeoLayer;
 import com.klikli_dev.occultism.common.entity.spirit.wonderingtrader.WonderingTraderEntity;
@@ -33,6 +36,7 @@ import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.EntityRendererProvider.Context;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import com.geckolib.renderer.layer.GeoRenderLayer;
 
@@ -52,5 +56,33 @@ public class WonderingTraderRenderer extends OccultismGeoLivingEntityRenderer<Wo
             poseStack.scale(1.2F, 1.2F, 1.2F);
         }
         super.submit(state, poseStack, submitNodeCollector, camera);
+    }
+
+    @Override
+    public void adjustModelBonesForRender(RenderPassInfo<OccultismGeoLivingEntityRenderState> renderPassInfo, BoneSnapshots snapshots) {
+        super.adjustModelBonesForRender(renderPassInfo, snapshots);
+
+        float headYaw = renderPassInfo.renderState().yRot * Mth.DEG_TO_RAD;
+        float headPitch = -renderPassInfo.renderState().xRot * Mth.DEG_TO_RAD;
+
+        snapshots.ifPresent("head", bone -> bone.setRotY(headYaw).setRotX(headPitch));
+        snapshots.ifPresent("head3", bone -> bone.setRotY(headYaw).setRotX(headPitch));
+
+        Player player = Minecraft.getInstance().player;
+        boolean showOtherForm = player != null && (player.hasEffect(OccultismEffects.THIRD_EYE) || CuriosUtil.hasGoggles(player) || CuriosUtil.hasStaff(player));
+
+        this.hideChildrenRecursive(renderPassInfo, snapshots, "common", showOtherForm);
+        this.hideChildrenRecursive(renderPassInfo, snapshots, "other", !showOtherForm);
+    }
+
+    private void hideChildrenRecursive(RenderPassInfo<OccultismGeoLivingEntityRenderState> renderPassInfo, BoneSnapshots snapshots, String rootBoneName, boolean hide) {
+        renderPassInfo.model().getBone(rootBoneName).ifPresent(rootBone -> this.hideChildrenRecursive(rootBone, snapshots, hide));
+    }
+
+    private void hideChildrenRecursive(GeoBone bone, BoneSnapshots snapshots, boolean hide) {
+        for (GeoBone child : bone.children()) {
+            snapshots.get(child).skipRender(hide);
+            this.hideChildrenRecursive(child, snapshots, hide);
+        }
     }
 }

--- a/src/main/resources/assets/occultism/geckolib/animations/entity/wondering_trader.animation.json
+++ b/src/main/resources/assets/occultism/geckolib/animations/entity/wondering_trader.animation.json
@@ -1,6 +1,45 @@
 {
 	"format_version": "1.8.0",
 	"animations": {
+		"idle": {
+			"loop": true,
+			"animation_length": 2,
+			"bones": {
+				"common": {
+					"position": {
+						"0.0": [0, 0, 0],
+						"1.0": [0, 0.15, 0],
+						"2.0": [0, 0, 0]
+					}
+				},
+				"other": {
+					"position": {
+						"0.0": [0, 0, 0],
+						"1.0": [0, 0.15, 0],
+						"2.0": [0, 0, 0]
+					}
+				}
+			}
+		},
+		"attack": {
+			"animation_length": 0.5,
+			"bones": {
+				"common": {
+					"position": {
+						"0.0": [0, 0, 0],
+						"0.25": [0, 0, 1],
+						"0.5": [0, 0, 0]
+					}
+				},
+				"other": {
+					"position": {
+						"0.0": [0, 0, 0],
+						"0.25": [0, 0, 1],
+						"0.5": [0, 0, 0]
+					}
+				}
+			}
+		},
 		"walk": {
 			"loop": true,
 			"animation_length": 1,


### PR DESCRIPTION
## Summary
- add missing GeckoLib idle and ttack animations for the custom wondering trader entity
- prevent ritual-spawned wandering traders from crashing the client during render-state extraction on 26.1.2
- keep the fix minimal by only updating the trader animation asset