### PR TITLE
fix: address remaining PR 1578 follow-up issues

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/client/gui/IesniumAnvilMenu.java
+++ b/src/main/java/com/klikli_dev/occultism/client/gui/IesniumAnvilMenu.java
@@ -46,17 +46,17 @@ public class IesniumAnvilMenu extends AnvilMenu {
         ItemStack leftInput = this.inputSlots.getItem(0).copy();
         ItemStack rightInput = this.inputSlots.getItem(1).copy();
 
+        if (NeoForge.EVENT_BUS.post(new AnvilCraftEvent.Pre(this, player, leftInput, rightInput, stack)).isCanceled()) {
+            this.broadcastChanges();
+            return;
+        }
+
         if (!player.getAbilities().instabuild) {
             if(ApothicEnchantingIntegration.isLoaded()) {
                 player.giveExperiencePoints(-ApothicEnchantingIntegration.getTotalExperiencePointsForLevel(this.cost.get() / 2));
             } else {
                 player.giveExperienceLevels(-this.cost.get() / 2);
             }
-        }
-
-        if (NeoForge.EVENT_BUS.post(new AnvilCraftEvent.Pre(this, player, leftInput, rightInput, stack)).isCanceled()) {
-            this.broadcastChanges();
-            return;
         }
         this.inputSlots.setItem(0, ItemStack.EMPTY);
         if (this.repairItemCountCost > 0) {

--- a/src/main/java/com/klikli_dev/occultism/client/render/entity/GuardianFamiliarRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/entity/GuardianFamiliarRenderer.java
@@ -28,9 +28,7 @@ import com.klikli_dev.occultism.client.render.entity.state.GuardianFamiliarRende
 import com.klikli_dev.occultism.common.entity.familiar.GuardianFamiliarEntity;
 import com.klikli_dev.occultism.registry.OccultismModelLayers;
 import com.klikli_dev.occultism.util.FamiliarUtil;
-import net.minecraft.client.Minecraft;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider.Context;
 import net.minecraft.client.renderer.item.ItemModelResolver;
 import net.minecraft.client.renderer.SubmitNodeCollector;
@@ -45,8 +43,11 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.model.Model;
 import org.joml.Quaternionf;
+
+import java.util.function.Function;
+import net.minecraft.client.renderer.rendertype.RenderType;
 
 
 public class GuardianFamiliarRenderer extends MobRenderer<GuardianFamiliarEntity, GuardianFamiliarRenderState, GuardianFamiliarModel> {
@@ -213,8 +214,12 @@ public class GuardianFamiliarRenderer extends MobRenderer<GuardianFamiliarEntity
     }
 
     private static class BirdLayer extends RenderLayer<GuardianFamiliarRenderState, GuardianFamiliarModel> {
+        private final BirdOnlyModel birdModel;
+
         public BirdLayer(RenderLayerParent<GuardianFamiliarRenderState, GuardianFamiliarModel> parent) {
             super(parent);
+            GuardianFamiliarModel model = parent.getModel();
+            this.birdModel = new BirdOnlyModel(model.birdBody, model::renderType);
         }
 
         @Override
@@ -224,14 +229,17 @@ public class GuardianFamiliarRenderer extends MobRenderer<GuardianFamiliarEntity
                 return;
             }
 
-            MultiBufferSource.BufferSource bufferSource = Minecraft.getInstance().renderBuffers().bufferSource();
-            VertexConsumer vertexConsumer = bufferSource.getBuffer(model.renderType(TEXTURES));
             poseStack.pushPose();
-            poseStack.translate(model.body.x / 16d, model.body.y / 16d, model.body.z / 16d);
-            poseStack.translate(0.35, -0.2, 0);
-            model.birdBody.render(poseStack, vertexConsumer, lightCoords, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
+            model.body.translateAndRotate(poseStack);
+            model.leftArm1.translateAndRotate(poseStack);
+            RenderLayer.renderColoredCutoutModel(this.birdModel, TEXTURES, poseStack, submitNodeCollector, lightCoords, state, -1, 0);
             poseStack.popPose();
-            bufferSource.endBatch(model.renderType(TEXTURES));
+        }
+
+        private static class BirdOnlyModel extends Model<GuardianFamiliarRenderState> {
+            public BirdOnlyModel(net.minecraft.client.model.geom.ModelPart root, Function<Identifier, RenderType> renderType) {
+                super(root, renderType);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- move the iesnium anvil `AnvilCraftEvent.Pre` hook before XP and input side effects to match NeoForge's contract
- route the guardian familiar bird layer through the 1.21 submit pipeline instead of forcing an immediate buffer flush
- follow up on review feedback from #1578 after the original PR was already merged

## Validation
- `./gradlew.bat compileJava`

## Related
- Follow-up to #1578