### PR TITLE
fix: consume golden bowl activation item on ritual completion

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
@@ -686,8 +686,16 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
             var recipe = this.getCurrentRitualRecipe();
             if (recipe != null) {
                 if (finished) {
-                    ItemStack activationItem = this.itemStackHandler.getResource(0).toStack();
+                    var activationResource = this.itemStackHandler.getResource(0);
+                    ItemStack activationItem = activationResource.toStack();
                     recipe.value().getRitual().finish(this.level, this.getBlockPos(), this, this.castingPlayer, activationItem);
+
+                    try (var tx = Transaction.openRoot()) {
+                        int extracted = this.itemStackHandler.extract(0, activationResource, 1, tx);
+                        if (extracted > 0) {
+                            tx.commit();
+                        }
+                    }
                 } else {
                     recipe.value().getRitual().interrupt(this.level, this.getBlockPos(), this, this.castingPlayer,
                             this.itemStackHandler.getResource(0).toStack(), showInterruptedMessage);


### PR DESCRIPTION
## Summary
- restore successful golden sacrificial bowl ritual completion to actually consume the activation item from the bowl inventory
- preserve existing ritual inish(...) behavior while explicitly extracting the real inventory item via the transfer handler resource
- align the 26.1.2 implementation with the working 1.21.1 ritual completion flow

Closes #1572