### PR TITLE
fix: preserve spirit stack counts with resource handlers

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/DepositItemsBehaviour.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/ai/behaviour/DepositItemsBehaviour.java
@@ -63,11 +63,11 @@ public class DepositItemsBehaviour<E extends SpiritEntity> extends ExtendedBehav
                 ItemStacksResourceHandler entityItemHandler = entity.inventory;
                 var firstFilledSlot = ItemTransferUtil.getFirstFilledSlot(entityItemHandler);
                 if (firstFilledSlot != -1) {
-                    ItemStack duplicate = entityItemHandler.getResource(firstFilledSlot).toStack().copy();
+                    ItemStack duplicate = entityItemHandler.getResource(firstFilledSlot)
+                            .toStack(entityItemHandler.getAmountAsInt(firstFilledSlot)).copy();
 
-                    //simulate insertion
+                    //insert and write back remainder
                     ItemStack leftover = ItemTransferUtil.insertItem(depositItemHandler, duplicate, false);
-                    //if we inserted everything
                     try (var tx = Transaction.openRoot()) {
                         entityItemHandler.set(firstFilledSlot, ItemResource.of(leftover), leftover.getCount());
                         tx.commit();

--- a/src/main/java/com/klikli_dev/occultism/common/entity/spirit/SpiritEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/entity/spirit/SpiritEntity.java
@@ -514,7 +514,7 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
     @Override
     public ItemStack getItemBySlot(EquipmentSlot slotIn) {
         if (slotIn == EquipmentSlot.MAINHAND) {
-            return this.inventory.getResource(0).toStack();
+            return this.inventory.getResource(0).toStack(this.inventory.getAmountAsInt(0));
         }
         return ItemStack.EMPTY;
     }
@@ -647,7 +647,7 @@ public abstract class SpiritEntity extends TamableAnimal implements ISkinnedCrea
     protected void dropEquipment(ServerLevel level) {
         super.dropEquipment(level);
         for (int i = 0; i < this.inventory.size(); ++i) {
-            ItemStack itemstack = this.inventory.getResource(i).toStack();
+            ItemStack itemstack = this.inventory.getResource(i).toStack(this.inventory.getAmountAsInt(i));
             if (!itemstack.isEmpty()) {
                 this.spawnAtLocation(level, itemstack, 0.0F);
             }


### PR DESCRIPTION
## Summary
- restore full item counts when spirit inventories are exposed as held stacks so crusher, smelter, crystallizer, trader, and render/UI paths see the real stack size
- preserve full stack counts when deposit behaviour reconstructs a spirit inventory stack for insertion, preventing stack loss after the resource handler migration
- validated with ./gradlew.bat compileJava

## Context
This fixes the 26.1.2 regression where stacked spirit job inputs could display as a single item and be consumed incorrectly after moving to the new resource handler APIs.

Closes #1570