### PR TITLE
fix: update loot modifier codec and familiar item handlers

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/handlers/FamiliarEventHandler.java
+++ b/src/main/java/com/klikli_dev/occultism/handlers/FamiliarEventHandler.java
@@ -33,6 +33,7 @@ import com.klikli_dev.occultism.registry.OccultismEntities;
 import com.klikli_dev.occultism.registry.OccultismItems;
 import com.klikli_dev.occultism.util.FamiliarUtil;
 import com.klikli_dev.occultism.util.ItemNBTUtil;
+import com.klikli_dev.occultism.util.ItemTransferUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -62,7 +63,6 @@ import net.neoforged.neoforge.event.entity.living.MobEffectEvent.Applicable.Resu
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent.BreakSpeed;
 import net.neoforged.neoforge.event.level.BlockGrowFeatureEvent;
-import net.neoforged.neoforge.items.ItemHandlerHelper;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.SlotResult;
 
@@ -236,7 +236,7 @@ public class FamiliarEventHandler {
                     event.getEntity().level().addFreshEntity(e);
                     ((GuardianFamiliarEntity) e).sacrifice();
                     ring.stack().shrink(1);
-                    ItemHandlerHelper.giveItemToPlayer(player, new ItemStack(OccultismItems.FAMILIAR_RING.get()));
+                    ItemTransferUtil.giveItemToPlayer(player, new ItemStack(OccultismItems.FAMILIAR_RING.get()));
                     return e;
                 });
             }

--- a/src/main/java/com/klikli_dev/occultism/integration/emi/impl/recipes/RitualRecipeCategory.java
+++ b/src/main/java/com/klikli_dev/occultism/integration/emi/impl/recipes/RitualRecipeCategory.java
@@ -66,9 +66,11 @@ public class RitualRecipeCategory implements EmiRecipe {
 
     @Override
     public List<EmiIngredient> getInputs() {
-        List<EmiIngredient> inputs = this.recipe.getIngredients().stream().map(EmiIngredient::of).collect(Collectors.toCollection(ArrayList::new));
-        inputs.add(EmiIngredient.of(this.recipe.getActivationItem()));
-        return inputs;
+        return Stream.concat(
+                        Stream.of(EmiIngredient.of(this.recipe.getActivationItem())),
+                        this.recipe.getIngredients().stream().map(EmiIngredient::of)
+                )
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/loot/AddItemModifier.java
+++ b/src/main/java/com/klikli_dev/occultism/loot/AddItemModifier.java
@@ -41,21 +41,24 @@ public class AddItemModifier extends LootModifier {
 
     public static final Supplier<MapCodec<AddItemModifier>> CODEC = Suppliers.memoize(() ->
             RecordCodecBuilder.mapCodec(instance ->
-                    instance.group(
-                                    LOOT_CONDITIONS_CODEC.fieldOf("conditions").forGetter(lm -> lm.conditions),
+                    LootModifier.codecStart(instance)
+                            .and(instance.group(
                                     BuiltInRegistries.ITEM.byNameCodec().fieldOf("item").forGetter(lm -> lm.addedItem),
-                                    Codec.intRange(0, Integer.MAX_VALUE).fieldOf("count").forGetter((lm) -> lm.count)
-                            )
-
+                                    Codec.intRange(0, Integer.MAX_VALUE).fieldOf("count").forGetter(lm -> lm.count)
+                            ))
                             .apply(instance, AddItemModifier::new)));
 
     private final Item addedItem;
     private final int count;
 
-    public AddItemModifier(LootItemCondition[] conditionsIn, Item addedItemIn, int count) {
-        super(conditionsIn);
+    public AddItemModifier(LootItemCondition[] conditionsIn, int priority, Item addedItemIn, int count) {
+        super(conditionsIn, priority);
         this.addedItem = addedItemIn;
         this.count = count;
+    }
+
+    public AddItemModifier(LootItemCondition[] conditionsIn, Item addedItemIn, int count) {
+        this(conditionsIn, IGlobalLootModifier.DEFAULT_PRIORITY, addedItemIn, count);
     }
 
     @Override

--- a/src/main/java/com/klikli_dev/occultism/util/FamiliarUtil.java
+++ b/src/main/java/com/klikli_dev/occultism/util/FamiliarUtil.java
@@ -30,6 +30,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -114,13 +115,16 @@ public class FamiliarUtil {
         if (handler == null)
             return familiars;
 
-        var curios = handler.getEquippedCurios();
-        for (int i = 0; i < curios.getSlots(); i++) {
-            IFamiliar familiar = FamiliarRingItem.getFamiliar(curios.getStackInSlot(i), owner.level());
-            if (familiar != null && familiar.getFamiliarEntity().getType() == type) {
-                T fam = (T) familiar.getFamiliarEntity();
-                if (pred.test(fam))
-                    familiars.add(fam);
+        for (ICurioStacksHandler curios : handler.getCurios().values()) {
+            var stacks = curios.getStacks();
+            for (int i = 0; i < stacks.getSlots(); i++) {
+                IFamiliar familiar = FamiliarRingItem.getFamiliar(stacks.getStackInSlot(i), owner.level());
+                if (familiar != null && familiar.getFamiliarEntity().getType() == type) {
+                    T fam = (T) familiar.getFamiliarEntity();
+                    if (pred.test(fam)) {
+                        familiars.add(fam);
+                    }
+                }
             }
         }
 

--- a/src/main/java/com/klikli_dev/occultism/util/ItemTransferUtil.java
+++ b/src/main/java/com/klikli_dev/occultism/util/ItemTransferUtil.java
@@ -4,6 +4,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.tags.TagKey;
+import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.ResourceHandlerUtil;
 import net.neoforged.neoforge.transfer.item.ItemResource;
@@ -103,6 +104,15 @@ public final class ItemTransferUtil {
     }
 
     public static void giveItemToPlayer(Player player, ItemStack stack) {
+        if (stack.isEmpty()) {
+            return;
+        }
+
+        var handler = player.getCapability(Capabilities.Item.ENTITY);
+        if (handler != null) {
+            stack = insertItemStacked(handler, stack, false);
+        }
+
         if (!stack.isEmpty()) {
             player.getInventory().placeItemBackInInventory(stack);
         }


### PR DESCRIPTION
## Summary
- update AddItemModifier for the new NeoForge loot modifier priority codec/constructor shape
- replace deprecated familiar item handler usage with transfer/Curios stack handler access
- include the existing EMI ritual recipe category refactor already present on this branch

Closes #1585