### PR TITLE
fix: restore familiar ring effects

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/FamiliarRingItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/FamiliarRingItem.java
@@ -59,6 +59,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import top.theillusivec4.curios.api.CuriosCapability;
+import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.type.capability.ICurio;
 
 import java.util.function.Consumer;
@@ -217,14 +218,14 @@ public class FamiliarRingItem extends Item {
             return this.stack;
         }
 
-        public void curioTick(LivingEntity entity) {
+        @Override
+        public void curioTick(SlotContext slotContext) {
+            LivingEntity entity = slotContext.entity();
             Level level = entity.level();
             IFamiliar familiar = this.getFamiliar(level);
             if (familiar != null) {
                 if (!familiar.getFamiliarEntity().isAddedToLevel())
                     familiar.getFamiliarEntity().setLevel(level);
-                if (familiar.getFamiliarOwner() == null)
-                    familiar.setFamiliarOwner(entity);
                 if (familiar.getFamiliarOwner() != entity)
                     return;
                 if (!level.isClientSide() && entity.tickCount % 20 == 0 && familiar.isEffectEnabled(entity))

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/FamiliarRingItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/FamiliarRingItem.java
@@ -256,6 +256,10 @@ public class FamiliarRingItem extends Item {
             if (this.familiar != null)
                 return this.familiar;
 
+            if (!level.isClientSide() && this.stack.getItem() instanceof FamiliarRingItem familiarRingItem) {
+                familiarRingItem.handleFamiliarTypeTag(this.stack);
+            }
+
             var data = this.stack.get(OccultismDataComponents.FAMILIAR_DATA);
             var tag = data == null ? null : data.copyTag();
             if (tag != null && (this.cachedNbt == null || !this.cachedNbt.equals(tag))) {

--- a/src/main/java/com/klikli_dev/occultism/common/item/tool/FamiliarRingItem.java
+++ b/src/main/java/com/klikli_dev/occultism/common/item/tool/FamiliarRingItem.java
@@ -223,6 +223,8 @@ public class FamiliarRingItem extends Item {
             if (familiar != null) {
                 if (!familiar.getFamiliarEntity().isAddedToLevel())
                     familiar.getFamiliarEntity().setLevel(level);
+                if (familiar.getFamiliarOwner() == null)
+                    familiar.setFamiliarOwner(entity);
                 if (familiar.getFamiliarOwner() != entity)
                     return;
                 if (!level.isClientSide() && entity.tickCount % 20 == 0 && familiar.isEffectEnabled(entity))


### PR DESCRIPTION
## Summary
- materialize familiar ring data from familiar type before loading the stored familiar
- use the current Curios slot tick hook so equipped familiar rings actually tick again
- closes #1589