### PR TITLE
[1.21.1] Battlefield custom loot and more compatibility

### DIFF
--- a/src/generated/resources/data/occultism/loot_table/battlefield/minecraft/ender_dragon.json
+++ b/src/generated/resources/data/occultism/loot_table/battlefield/minecraft/ender_dragon.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dragon_breath",
+          "weight": 3
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dragon_egg"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "occultism:battlefield/minecraft/ender_dragon"
+}

--- a/src/generated/resources/data/occultism/loot_table/battlefield/minecraft/wither.json
+++ b/src/generated/resources/data/occultism/loot_table/battlefield/minecraft/wither.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:nether_star"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "occultism:battlefield/minecraft/wither"
+}

--- a/src/generated/resources/data/occultism/tags/entity_type/force_kill_simulation.json
+++ b/src/generated/resources/data/occultism/tags/entity_type/force_kill_simulation.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "minecraft:wither"
-  ]
-}

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
@@ -354,19 +354,22 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
         BlockPos pos = this.worldPosition;
         entity.moveTo(pos.getCenter());
         if (this.storedLootTable != null) {
-            for (int i = 0; i < rolls; i++) {
-                Collection<ItemEntity> dropsCollection = new ArrayList<>();
-                ObjectArrayList<ItemStack> loot = this.storedLootTable.getRandomItems(lootparams);
-                for (ItemStack itemStack : loot) {
-                    ItemEntity itemEntity = new ItemEntity(this.level, pos.getX(), pos.getY(), pos.getZ(), itemStack);
-                    dropsCollection.add(itemEntity);
+            NeoForge.EVENT_BUS.addListener(this.entityJoinLevelEventListener);
+            try {
+                for (int i = 0; i < rolls; i++) {
+                    Collection<ItemEntity> dropsCollection = new ArrayList<>();
+                    ObjectArrayList<ItemStack> loot = this.storedLootTable.getRandomItems(lootparams);
+                    for (ItemStack itemStack : loot) {
+                        ItemEntity itemEntity = new ItemEntity(this.level, pos.getX(), pos.getY(), pos.getZ(), itemStack);
+                        dropsCollection.add(itemEntity);
+                    }
+                    LivingDropsEvent event = new LivingDropsEvent(entity, lootparams.getParameter(LootContextParams.DAMAGE_SOURCE), dropsCollection, true);
+                    NeoForge.EVENT_BUS.post(event);
+                    if (!event.isCanceled())
+                        for (ItemEntity item : event.getDrops())
+                            ItemHandlerHelper.insertItemStacked(currentHandler, item.getItem(), false);
                 }
-                LivingDropsEvent event = new LivingDropsEvent(entity, lootparams.getParameter(LootContextParams.DAMAGE_SOURCE), dropsCollection, true);
-                NeoForge.EVENT_BUS.post(event);
-                NeoForge.EVENT_BUS.addListener(this.entityJoinLevelEventListener);
-                if (!event.isCanceled())
-                    for (ItemEntity item : event.getDrops())
-                        ItemHandlerHelper.insertItemStacked(currentHandler, item.getItem(), false);
+            } finally {
                 NeoForge.EVENT_BUS.unregister(this.entityJoinLevelEventListener);
             }
         }

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
@@ -367,7 +367,7 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
                 if (!event.isCanceled())
                     for (ItemEntity item : event.getDrops())
                         ItemHandlerHelper.insertItemStacked(currentHandler, item.getItem(), false);
-                NeoForge.EVENT_BUS.addListener(this.entityJoinLevelEventListener);
+                NeoForge.EVENT_BUS.unregister(this.entityJoinLevelEventListener);
             }
         }
     }
@@ -512,7 +512,7 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
             return;
 
         Entity entity = event.getEntity();
-        if (entity.position().distanceTo(this.getBlockPos().getCenter()) > 1)
+        if (entity.position().distanceToSqr(this.getBlockPos().getCenter()) > 1)
             return;
 
         if (entity instanceof ExperienceOrb orb) {

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalBattlefieldBlockEntity.java
@@ -45,11 +45,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.EntityTypeTags;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.MenuProvider;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.ExperienceOrb;
-import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
@@ -73,6 +71,7 @@ import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.util.FakePlayer;
 import net.neoforged.neoforge.common.util.FakePlayerFactory;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
+import net.neoforged.neoforge.event.entity.living.LivingDropsEvent;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 import net.neoforged.neoforge.items.ItemHandlerHelper;
@@ -82,6 +81,8 @@ import net.neoforged.neoforge.items.wrapper.RangedWrapper;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -348,31 +349,25 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
             ItemHandlerHelper.insertItemStacked(currentHandler, bottleStack, false);
         }
 
-        //TODO: Custom drops with json recipes (planned for mc 26.1)
-        if (entity.getType().equals(EntityType.ENDER_DRAGON))
-            ItemHandlerHelper.insertItemStacked(currentHandler, Items.DRAGON_EGG.getDefaultInstance(), false);
-
-        FakePlayer fakePlayer = this.getFakePlayer();
-        if (entity.getType().is(OccultismTags.Entities.FORCE_KILL_SIMULATION)) {
-            NeoForge.EVENT_BUS.addListener(this.entityJoinLevelEventListener);
-            for (int i = 0; i < rolls; i++) {
-                Entity clone = entity.getType().create(this.level);
-                if (clone != null) {
-                    clone.moveTo(this.getBlockPos().getX(), -100, this.getBlockPos().getZ());
-                    clone.hurt(this.level.damageSources().playerAttack(fakePlayer), Integer.MAX_VALUE);
-                }
-            }
-            NeoForge.EVENT_BUS.unregister(this.entityJoinLevelEventListener);
-            return;
-        }
-
-        this.xpStored += entity.getExperienceReward((ServerLevel) this.level, fakePlayer);
+        this.xpStored += entity.getExperienceReward((ServerLevel) this.level, this.getFakePlayer());
         LootParams lootparams = this.setLootParams(entity, luck);
+        BlockPos pos = this.worldPosition;
+        entity.moveTo(pos.getCenter());
         if (this.storedLootTable != null) {
             for (int i = 0; i < rolls; i++) {
+                Collection<ItemEntity> dropsCollection = new ArrayList<>();
                 ObjectArrayList<ItemStack> loot = this.storedLootTable.getRandomItems(lootparams);
-                for (ItemStack itemStack : loot)
-                    ItemHandlerHelper.insertItemStacked(currentHandler, itemStack, false);
+                for (ItemStack itemStack : loot) {
+                    ItemEntity itemEntity = new ItemEntity(this.level, pos.getX(), pos.getY(), pos.getZ(), itemStack);
+                    dropsCollection.add(itemEntity);
+                }
+                LivingDropsEvent event = new LivingDropsEvent(entity, lootparams.getParameter(LootContextParams.DAMAGE_SOURCE), dropsCollection, true);
+                NeoForge.EVENT_BUS.post(event);
+                NeoForge.EVENT_BUS.addListener(this.entityJoinLevelEventListener);
+                if (!event.isCanceled())
+                    for (ItemEntity item : event.getDrops())
+                        ItemHandlerHelper.insertItemStacked(currentHandler, item.getItem(), false);
+                NeoForge.EVENT_BUS.addListener(this.entityJoinLevelEventListener);
             }
         }
     }
@@ -408,11 +403,16 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
             if (this.storedLivingEntity instanceof PossessedMob possessed && !stack.is(OccultismItems.TRINITY_GEM_ITEM)) {
                 EntityType<?> baseMob = possessed.basedMob();
                 if (baseMob != null && baseMob.create(level) instanceof LivingEntity entity) {
-                    this.storedLootTable = level.getServer().reloadableRegistries().getLootTable(entity.getLootTable());
-                    return;
+                    this.storedLivingEntity = entity;
                 }
             }
-            this.storedLootTable = level.getServer().reloadableRegistries().getLootTable(this.storedLivingEntity.getLootTable());
+            ResourceKey<LootTable> customLoot = ResourceKey.create(Registries.LOOT_TABLE,
+                    ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "battlefield/"
+                            + BuiltInRegistries.ENTITY_TYPE.getKey(this.storedLivingEntity.getType()).toString().replace(":","/")));
+            this.storedLootTable = level.getServer().reloadableRegistries().getLootTable(customLoot);
+            if (this.storedLootTable == LootTable.EMPTY) {
+                this.storedLootTable = level.getServer().reloadableRegistries().getLootTable(this.storedLivingEntity.getLootTable());
+            }
         } else {
             this.storedLootTable = null;
         }
@@ -422,13 +422,13 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
         ServerLevel serverLevel = (ServerLevel) this.level;
         FakePlayer fakePlayer = this.getFakePlayer();
         ItemStack weapon = this.inputWeaponHandler.getStackInSlot(0);
-
+        fakePlayer.setItemInHand(InteractionHand.MAIN_HAND, weapon);
         assert serverLevel != null;
         return new LootParams.Builder(serverLevel)
                 .withParameter(LootContextParams.THIS_ENTITY, entity)
                 .withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(this.worldPosition))
-                .withParameter(LootContextParams.DAMAGE_SOURCE, fakePlayer.damageSources().generic())
-                .withParameter(LootContextParams.LAST_DAMAGE_PLAYER, fakePlayer)
+                .withParameter(LootContextParams.DAMAGE_SOURCE, fakePlayer.damageSources().playerAttack(fakePlayer))
+                .withOptionalParameter(LootContextParams.LAST_DAMAGE_PLAYER, fakePlayer)
                 .withOptionalParameter(LootContextParams.ATTACKING_ENTITY, fakePlayer)
                 .withOptionalParameter(LootContextParams.DIRECT_ATTACKING_ENTITY, fakePlayer)
                 .withOptionalParameter(LootContextParams.TOOL, weapon)
@@ -508,27 +508,23 @@ public class DimensionalBattlefieldBlockEntity extends NetworkedBlockEntity impl
 
     @SubscribeEvent
     public void itemEntityConsumer(EntityJoinLevelEvent event) {
-        Level level = event.getLevel();
-        if (level.isClientSide())
+        if (event.getLevel().isClientSide())
             return;
 
         Entity entity = event.getEntity();
-        if (entity.getX() != this.getBlockPos().getX() || entity.getY() != -100 || entity.getZ() != this.getBlockPos().getZ())
+        if (entity.position().distanceTo(this.getBlockPos().getCenter()) > 1)
             return;
 
-        if (entity instanceof ItemEntity item) {
-            IItemHandler currentHandler = this.getCurrentHandler();
-            ItemHandlerHelper.insertItemStacked(currentHandler, item.getItem(), false);
-            return;
-        }
         if (entity instanceof ExperienceOrb orb) {
             this.xpStored += orb.getValue();
+            event.setCanceled(true);
         }
     }
 
     private FakePlayer getFakePlayer() {
         if (cachedFakePlayer == null) {
             cachedFakePlayer = FakePlayerFactory.getMinecraft((ServerLevel) this.level);
+            cachedFakePlayer.moveTo(Vec3.atCenterOf(this.worldPosition));
         }
         return cachedFakePlayer;
     }

--- a/src/main/java/com/klikli_dev/occultism/datagen/loot/OccultismEntityLoot.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/loot/OccultismEntityLoot.java
@@ -1,20 +1,24 @@
 package com.klikli_dev.occultism.datagen.loot;
 
+import com.klikli_dev.occultism.Occultism;
 import com.klikli_dev.occultism.registry.OccultismEntities;
 import com.klikli_dev.occultism.registry.OccultismItems;
-import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderLookup.Provider;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.loot.EntityLootSubProvider;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.alchemy.Potions;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.storage.loot.BuiltInLootTables;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.LootTable.Builder;
 import net.minecraft.world.level.storage.loot.entries.EmptyLootItem;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
-import net.minecraft.world.level.storage.loot.entries.NestedLootTable;
 import net.minecraft.world.level.storage.loot.functions.EnchantedCountIncreaseFunction;
 import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
 import net.minecraft.world.level.storage.loot.functions.SetPotionFunction;
@@ -28,12 +32,12 @@ import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
 import java.util.function.BiConsumer;
 
 public class OccultismEntityLoot extends EntityLootSubProvider {
-    public OccultismEntityLoot(HolderLookup.Provider pRegistries) {
+    public OccultismEntityLoot(Provider pRegistries) {
         super(FeatureFlags.REGISTRY.allFlags(), pRegistries);
     }
 
     @Override
-    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> pGenerator) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, Builder> pGenerator) {
         this.generate();
         this.map.forEach((key, entityType) -> {
             entityType.forEach(pGenerator::accept);
@@ -43,6 +47,17 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
 
     @Override
     public void generate() {
+        this.battlefieldLoot(EntityType.WITHER, LootTable.lootTable()
+                .withPool(LootPool.lootPool().setRolls(ConstantValue.exactly(1.0F))
+                        .add(LootItem.lootTableItem(Items.NETHER_STAR)))
+        );
+        this.battlefieldLoot(EntityType.ENDER_DRAGON, LootTable.lootTable()
+                .withPool(LootPool.lootPool().setRolls(ConstantValue.exactly(1.0F))
+                        .add(LootItem.lootTableItem(Items.DRAGON_BREATH).setWeight(3))
+                        .add(LootItem.lootTableItem(Items.DRAGON_EGG)))
+        );
+
+
         this.add(OccultismEntities.POSSESSED_SHULKER_TYPE.get(), this.shulkerLootTable());
         this.add(OccultismEntities.POSSESSED_WARDEN_TYPE.get(), this.wardenLootTable());
         this.add(OccultismEntities.POSSESSED_HOGLIN_TYPE.get(), this.hoglinLootTable());
@@ -51,7 +66,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
         this.add(OccultismEntities.POSSESSED_WEAK_SHULKER_TYPE.get(), this.weakShulkerTable());
         this.add(OccultismEntities.POSSESSED_GHAST_TYPE.get(), this.ghastLootTable());
         this.add(OccultismEntities.POSSESSED_ELDER_GUARDIAN_TYPE.get(), this.elderGuardianLootTable());
-        this.add(OccultismEntities.WILD_HORDE_HUSK_TYPE.get(), this.huskLootTable());
+        this.add(OccultismEntities.WILD_HORDE_HUSK_TYPE.get(), this.desertLootTable());
         this.add(OccultismEntities.WILD_HORDE_DROWNED_TYPE.get(), this.drownedLootTable());
         this.add(OccultismEntities.WILD_HORDE_CREEPER_TYPE.get(), this.creeperLootTable());
         this.add(OccultismEntities.WILD_HORDE_SILVERFISH_TYPE.get(), this.silverfishLootTable());
@@ -62,21 +77,21 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
         this.add(OccultismEntities.POSSESSED_GUARDIAN_TYPE.get(), this.guardianLootTable());
         this.add(OccultismEntities.POSSESSED_ENDERMITE_TYPE.get(),
                 LootTable.lootTable().withPool(
-                        LootPool.lootPool().setRolls(ConstantValue.exactly(1))
-                                .add(LootItem.lootTableItem(Items.END_STONE).setWeight(99)
-                                        .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0f, 2.0F)))
+                                LootPool.lootPool().setRolls(ConstantValue.exactly(1))
+                                        .add(LootItem.lootTableItem(Items.END_STONE).setWeight(99)
+                                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0f, 2.0F)))
+                                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F))))
+                                        .add(LootItem.lootTableItem(Items.END_STONE_BRICKS).setWeight(1)
+                                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0f, 2.0F)))
+                                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F)))))
+                        .withPool(LootPool.lootPool().setRolls(ConstantValue.exactly(1))
+                                .add(LootItem.lootTableItem(Items.FERMENTED_SPIDER_EYE).setWeight(2)
                                         .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F))))
-                                .add(LootItem.lootTableItem(Items.END_STONE_BRICKS).setWeight(1)
-                                        .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0f, 2.0F)))
-                                        .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F)))))
-                .withPool(LootPool.lootPool().setRolls(ConstantValue.exactly(1))
-                        .add(LootItem.lootTableItem(Items.FERMENTED_SPIDER_EYE).setWeight(2)
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F))))
-                        .add(LootItem.lootTableItem(Items.SPIDER_EYE).setWeight(2)
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F))))
-                        .add(LootItem.lootTableItem(Items.ENDER_EYE).setWeight(1)
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F))))
-                        .when(LootItemRandomChanceCondition.randomChance(ConstantValue.exactly(0.25F)))));
+                                .add(LootItem.lootTableItem(Items.SPIDER_EYE).setWeight(2)
+                                        .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F))))
+                                .add(LootItem.lootTableItem(Items.ENDER_EYE).setWeight(1)
+                                        .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F))))
+                                .when(LootItemRandomChanceCondition.randomChance(ConstantValue.exactly(0.25F)))));
 
         //Guaranteed ender pearl drop for enderman
         this.add(OccultismEntities.POSSESSED_ENDERMAN_TYPE.get(),
@@ -112,14 +127,14 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
         this.add(OccultismEntities.POSSESSED_PHANTOM_TYPE.get(),
                 LootTable.lootTable()
                         .withPool(
-                            LootPool.lootPool().setRolls(ConstantValue.exactly(1))
-                                .add(LootItem.lootTableItem(Items.PHANTOM_MEMBRANE)
-                                        .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0f, 4.0F)))
-                                        .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.5F, 2.0F)))))
+                                LootPool.lootPool().setRolls(ConstantValue.exactly(1))
+                                        .add(LootItem.lootTableItem(Items.PHANTOM_MEMBRANE)
+                                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0f, 4.0F)))
+                                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.5F, 2.0F)))))
                         .withPool(LootPool.lootPool().setRolls(ConstantValue.exactly(1))
                                 .add(LootItem.lootTableItem(Items.WIND_CHARGE)
                                         .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F))))
-                                        .when(LootItemRandomChanceCondition.randomChance(ConstantValue.exactly(0.05F))))
+                                .when(LootItemRandomChanceCondition.randomChance(ConstantValue.exactly(0.05F))))
         );
 
         //Essence drop from wild afrit
@@ -182,10 +197,10 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
 
         this.add(OccultismEntities.POSSESSED_ZOMBIE_PIGLIN_TYPE.get(),
                 LootTable.lootTable().withPool(
-                        LootPool.lootPool().setRolls(ConstantValue.exactly(1))
-                                .add(LootItem.lootTableItem(OccultismItems.DEMONIC_MEAT)
-                                        .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 4.0F)))
-                                        .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F)))))
+                                LootPool.lootPool().setRolls(ConstantValue.exactly(1))
+                                        .add(LootItem.lootTableItem(OccultismItems.DEMONIC_MEAT)
+                                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 4.0F)))
+                                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0.0F, 1.0F)))))
                         .withPool(
                                 LootPool.lootPool().setRolls(ConstantValue.exactly(1))
                                         .add(LootItem.lootTableItem(OccultismItems.TALLOW)
@@ -215,7 +230,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
      *
      * @return
      */
-    public LootTable.Builder elderGuardianLootTable() {
+    public Builder elderGuardianLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -253,12 +268,12 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
-                                .add(
-                                        NestedLootTable.lootTableReference(BuiltInLootTables.FISHING_FISH)
-                                                .apply(
-                                                        SmeltItemFunction.smelted().when(this.shouldSmeltLoot())
-                                                )
-                                )
+                                .add(LootItem.lootTableItem(Items.COD).setWeight(2)
+                                        .apply(SmeltItemFunction.smelted().when(this.shouldSmeltLoot())))
+                                .add(LootItem.lootTableItem(Items.SALMON).setWeight(2)
+                                        .apply(SmeltItemFunction.smelted().when(this.shouldSmeltLoot())))
+                                .add(LootItem.lootTableItem(Items.TROPICAL_FISH))
+                                .add(LootItem.lootTableItem(Items.PUFFERFISH))
                                 .when(LootItemKilledByPlayerCondition.killedByPlayer())
                                 .when(LootItemRandomChanceWithEnchantedBonusCondition.randomChanceAndLootingBoost(this.registries, 0.025F, 0.01F))
                 )
@@ -289,7 +304,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 );
     }
 
-    public LootTable.Builder ghastLootTable(){
+    public Builder ghastLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -312,7 +327,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
 
     }
 
-    public LootTable.Builder hoglinLootTable(){
+    public Builder hoglinLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -326,7 +341,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 );
     }
 
-    public LootTable.Builder shulkerLootTable(){
+    public Builder shulkerLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -353,7 +368,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 );
     }
 
-    public LootTable.Builder wardenLootTable(){
+    public Builder wardenLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -390,7 +405,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 );
     }
 
-    public LootTable.Builder weakShulkerTable(){
+    public Builder weakShulkerTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -398,14 +413,15 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.SHULKER_SHELL)
                                         .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 1.0F))))
                                 .when(LootItemRandomChanceCondition.randomChance(0.1F))
-                ) .withPool(
+                ).withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
                                 .add(LootItem.lootTableItem(Items.CHORUS_FRUIT)
                                         .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 3.0F))))
                 );
     }
-    public LootTable.Builder huskLootTable(){
+
+    public Builder desertLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -424,7 +440,8 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.BREWER_POTTERY_SHERD).setWeight(1))
                 );
     }
-    public LootTable.Builder drownedLootTable(){
+
+    public Builder drownedLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -447,7 +464,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 )
                 .withPool(
                         LootPool.lootPool()
-                                .setRolls(UniformGenerator.between(1.0F,2.0F))
+                                .setRolls(UniformGenerator.between(1.0F, 2.0F))
                                 .add(EmptyLootItem.emptyItem().setWeight(2))
                                 .add(LootItem.lootTableItem(Items.COPPER_INGOT).setWeight(3))
                                 .add(LootItem.lootTableItem(Items.PRISMARINE_SHARD).setWeight(6))
@@ -455,7 +472,8 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, ConstantValue.exactly(1.0F)))
                 );
     }
-    public LootTable.Builder creeperLootTable(){
+
+    public Builder creeperLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -474,7 +492,8 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.MUSIC_DISC_WAIT).setWeight(1))
                 );
     }
-    public LootTable.Builder silverfishLootTable(){
+
+    public Builder silverfishLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -503,7 +522,8 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.SHEAF_POTTERY_SHERD).setWeight(1))
                 );
     }
-    public LootTable.Builder weakBreezeTable(){
+
+    public Builder weakBreezeTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -526,11 +546,13 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
-                                .add(EmptyLootItem.emptyItem().setWeight(7))
+                                .add(EmptyLootItem.emptyItem().setWeight(5))
+                                .add(LootItem.lootTableItem(Items.WIND_CHARGE).setWeight(3))
                                 .add(LootItem.lootTableItem(Items.MUSIC_DISC_CREATOR_MUSIC_BOX).setWeight(1))
                 );
     }
-    public LootTable.Builder breezeTable(){
+
+    public Builder breezeTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -552,7 +574,8 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.MUSIC_DISC_PRECIPICE).setWeight(1))
                 );
     }
-    public LootTable.Builder strongBreezeTable(){
+
+    public Builder strongBreezeTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -569,7 +592,8 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.MUSIC_DISC_CREATOR).setWeight(1))
                 );
     }
-    public LootTable.Builder evokerTable(){
+
+    public Builder evokerTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -590,7 +614,8 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .apply(SetItemCountFunction.setCount(UniformGenerator.between(0.5F, 2.0F)))
                 );
     }
-    public LootTable.Builder witchLootTable(){
+
+    public Builder witchLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -599,23 +624,23 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.HONEY_BOTTLE).setWeight(4))
                                 .add(LootItem.lootTableItem(Items.OMINOUS_BOTTLE).setWeight(2))
                                 .add(LootItem.lootTableItem(Items.POTION).setWeight(1).apply(SetPotionFunction.setPotion(Potions.WATER)))
-                ).apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,2)));
+                ).apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 2)));
     }
 
-    public LootTable.Builder blazeLootTable(){
+    public Builder blazeLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
                                 .add(LootItem.lootTableItem(Items.BLAZE_ROD))
-                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(2,6)))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,2)))
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(2, 6)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 2)))
                 )
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
                                 .add(LootItem.lootTableItem(Items.BLAZE_POWDER))
-                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(0,13))))
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(0, 13))))
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
@@ -628,7 +653,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.WARPED_ROOTS).setWeight(5))
                                 .add(LootItem.lootTableItem(Items.WEEPING_VINES).setWeight(5))
                                 .add(LootItem.lootTableItem(Items.TWISTING_VINES).setWeight(5))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(1,3)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(1, 3)))
                 )
                 .withPool(
                         LootPool.lootPool()
@@ -640,7 +665,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.WARPED_NYLIUM).setWeight(9))
                                 .add(LootItem.lootTableItem(Items.NETHER_WART_BLOCK).setWeight(1))
                                 .add(LootItem.lootTableItem(Items.WARPED_WART_BLOCK).setWeight(1))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 1)))
                 )
                 .withPool(
                         LootPool.lootPool()
@@ -653,17 +678,17 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.GRAVEL).setWeight(9))
                                 .add(LootItem.lootTableItem(Items.BONE_BLOCK).setWeight(5))
                                 .add(LootItem.lootTableItem(Items.GILDED_BLACKSTONE).setWeight(1))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 1)))
                 )
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
                                 .add(EmptyLootItem.emptyItem().setWeight(50))
-                                .add(LootItem.lootTableItem(Items.GLOWSTONE_DUST).setWeight(25).apply(SetItemCountFunction.setCount(UniformGenerator.between(1,6))))
+                                .add(LootItem.lootTableItem(Items.GLOWSTONE_DUST).setWeight(25).apply(SetItemCountFunction.setCount(UniformGenerator.between(1, 6))))
                                 .add(LootItem.lootTableItem(Items.MAGMA_BLOCK).setWeight(15))
                                 .add(LootItem.lootTableItem(Items.GLOWSTONE).setWeight(9))
                                 .add(LootItem.lootTableItem(Items.SHROOMLIGHT).setWeight(1))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 1)))
                 )
                 .withPool(
                         LootPool.lootPool()
@@ -672,11 +697,11 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.OBSIDIAN).setWeight(20))
                                 .add(LootItem.lootTableItem(Items.CRYING_OBSIDIAN).setWeight(4))
                                 .add(LootItem.lootTableItem(Items.ANCIENT_DEBRIS).setWeight(1))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,ConstantValue.exactly(1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, ConstantValue.exactly(1)))
                 );
     }
 
-    public LootTable.Builder guardianLootTable(){
+    public Builder guardianLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -703,7 +728,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.BUBBLE_CORAL))
                                 .add(LootItem.lootTableItem(Items.FIRE_CORAL))
                                 .add(LootItem.lootTableItem(Items.HORN_CORAL))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0,1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 1)))
                 )
                 .withPool(
                         LootPool.lootPool()
@@ -730,5 +755,13 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 )
                                 .add(EmptyLootItem.emptyItem().setWeight(3))
                 );
+    }
+
+    public void battlefieldLoot(EntityType<?> type, LootTable.Builder builder) {
+        ResourceKey<LootTable> customLootTable =  ResourceKey.create(Registries.LOOT_TABLE,
+                ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "battlefield/"
+                        + BuiltInRegistries.ENTITY_TYPE.getKey(type).toString().replace(":","/")));
+
+        this.add(type, customLootTable, builder);
     }
 }

--- a/src/main/java/com/klikli_dev/occultism/datagen/loot/OccultismEntityLoot.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/loot/OccultismEntityLoot.java
@@ -14,11 +14,13 @@ import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.alchemy.Potions;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.storage.loot.BuiltInLootTables;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.LootTable.Builder;
 import net.minecraft.world.level.storage.loot.entries.EmptyLootItem;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.entries.NestedLootTable;
 import net.minecraft.world.level.storage.loot.functions.EnchantedCountIncreaseFunction;
 import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
 import net.minecraft.world.level.storage.loot.functions.SetPotionFunction;
@@ -66,7 +68,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
         this.add(OccultismEntities.POSSESSED_WEAK_SHULKER_TYPE.get(), this.weakShulkerTable());
         this.add(OccultismEntities.POSSESSED_GHAST_TYPE.get(), this.ghastLootTable());
         this.add(OccultismEntities.POSSESSED_ELDER_GUARDIAN_TYPE.get(), this.elderGuardianLootTable());
-        this.add(OccultismEntities.WILD_HORDE_HUSK_TYPE.get(), this.desertLootTable());
+        this.add(OccultismEntities.WILD_HORDE_HUSK_TYPE.get(), this.huskLootTable());
         this.add(OccultismEntities.WILD_HORDE_DROWNED_TYPE.get(), this.drownedLootTable());
         this.add(OccultismEntities.WILD_HORDE_CREEPER_TYPE.get(), this.creeperLootTable());
         this.add(OccultismEntities.WILD_HORDE_SILVERFISH_TYPE.get(), this.silverfishLootTable());
@@ -230,7 +232,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
      *
      * @return
      */
-    public Builder elderGuardianLootTable() {
+    public LootTable.Builder elderGuardianLootTable() {
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -268,12 +270,12 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
-                                .add(LootItem.lootTableItem(Items.COD).setWeight(2)
-                                        .apply(SmeltItemFunction.smelted().when(this.shouldSmeltLoot())))
-                                .add(LootItem.lootTableItem(Items.SALMON).setWeight(2)
-                                        .apply(SmeltItemFunction.smelted().when(this.shouldSmeltLoot())))
-                                .add(LootItem.lootTableItem(Items.TROPICAL_FISH))
-                                .add(LootItem.lootTableItem(Items.PUFFERFISH))
+                                .add(
+                                        NestedLootTable.lootTableReference(BuiltInLootTables.FISHING_FISH)
+                                                .apply(
+                                                        SmeltItemFunction.smelted().when(this.shouldSmeltLoot())
+                                                )
+                                )
                                 .when(LootItemKilledByPlayerCondition.killedByPlayer())
                                 .when(LootItemRandomChanceWithEnchantedBonusCondition.randomChanceAndLootingBoost(this.registries, 0.025F, 0.01F))
                 )
@@ -304,7 +306,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 );
     }
 
-    public Builder ghastLootTable() {
+    public LootTable.Builder ghastLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -327,7 +329,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
 
     }
 
-    public Builder hoglinLootTable() {
+    public LootTable.Builder hoglinLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -341,7 +343,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 );
     }
 
-    public Builder shulkerLootTable() {
+    public LootTable.Builder shulkerLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -368,7 +370,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 );
     }
 
-    public Builder wardenLootTable() {
+    public LootTable.Builder wardenLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -405,7 +407,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 );
     }
 
-    public Builder weakShulkerTable() {
+    public LootTable.Builder weakShulkerTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -413,15 +415,14 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.SHULKER_SHELL)
                                         .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 1.0F))))
                                 .when(LootItemRandomChanceCondition.randomChance(0.1F))
-                ).withPool(
+                ) .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
                                 .add(LootItem.lootTableItem(Items.CHORUS_FRUIT)
                                         .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 3.0F))))
                 );
     }
-
-    public Builder desertLootTable() {
+    public LootTable.Builder huskLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -440,8 +441,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.BREWER_POTTERY_SHERD).setWeight(1))
                 );
     }
-
-    public Builder drownedLootTable() {
+    public LootTable.Builder drownedLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -464,7 +464,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 )
                 .withPool(
                         LootPool.lootPool()
-                                .setRolls(UniformGenerator.between(1.0F, 2.0F))
+                                .setRolls(UniformGenerator.between(1.0F,2.0F))
                                 .add(EmptyLootItem.emptyItem().setWeight(2))
                                 .add(LootItem.lootTableItem(Items.COPPER_INGOT).setWeight(3))
                                 .add(LootItem.lootTableItem(Items.PRISMARINE_SHARD).setWeight(6))
@@ -472,8 +472,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, ConstantValue.exactly(1.0F)))
                 );
     }
-
-    public Builder creeperLootTable() {
+    public LootTable.Builder creeperLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -492,8 +491,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.MUSIC_DISC_WAIT).setWeight(1))
                 );
     }
-
-    public Builder silverfishLootTable() {
+    public LootTable.Builder silverfishLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -522,8 +520,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.SHEAF_POTTERY_SHERD).setWeight(1))
                 );
     }
-
-    public Builder weakBreezeTable() {
+    public LootTable.Builder weakBreezeTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -546,13 +543,11 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
-                                .add(EmptyLootItem.emptyItem().setWeight(5))
-                                .add(LootItem.lootTableItem(Items.WIND_CHARGE).setWeight(3))
+                                .add(EmptyLootItem.emptyItem().setWeight(7))
                                 .add(LootItem.lootTableItem(Items.MUSIC_DISC_CREATOR_MUSIC_BOX).setWeight(1))
                 );
     }
-
-    public Builder breezeTable() {
+    public LootTable.Builder breezeTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -574,8 +569,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.MUSIC_DISC_PRECIPICE).setWeight(1))
                 );
     }
-
-    public Builder strongBreezeTable() {
+    public LootTable.Builder strongBreezeTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -592,8 +586,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.MUSIC_DISC_CREATOR).setWeight(1))
                 );
     }
-
-    public Builder evokerTable() {
+    public LootTable.Builder evokerTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -614,8 +607,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .apply(SetItemCountFunction.setCount(UniformGenerator.between(0.5F, 2.0F)))
                 );
     }
-
-    public Builder witchLootTable() {
+    public LootTable.Builder witchLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -624,23 +616,23 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.HONEY_BOTTLE).setWeight(4))
                                 .add(LootItem.lootTableItem(Items.OMINOUS_BOTTLE).setWeight(2))
                                 .add(LootItem.lootTableItem(Items.POTION).setWeight(1).apply(SetPotionFunction.setPotion(Potions.WATER)))
-                ).apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 2)));
+                ).apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,2)));
     }
 
-    public Builder blazeLootTable() {
+    public LootTable.Builder blazeLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
                                 .add(LootItem.lootTableItem(Items.BLAZE_ROD))
-                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(2, 6)))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 2)))
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(2,6)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,2)))
                 )
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
                                 .add(LootItem.lootTableItem(Items.BLAZE_POWDER))
-                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(0, 13))))
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(0,13))))
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
@@ -653,7 +645,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.WARPED_ROOTS).setWeight(5))
                                 .add(LootItem.lootTableItem(Items.WEEPING_VINES).setWeight(5))
                                 .add(LootItem.lootTableItem(Items.TWISTING_VINES).setWeight(5))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(1, 3)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(1,3)))
                 )
                 .withPool(
                         LootPool.lootPool()
@@ -665,7 +657,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.WARPED_NYLIUM).setWeight(9))
                                 .add(LootItem.lootTableItem(Items.NETHER_WART_BLOCK).setWeight(1))
                                 .add(LootItem.lootTableItem(Items.WARPED_WART_BLOCK).setWeight(1))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,1)))
                 )
                 .withPool(
                         LootPool.lootPool()
@@ -678,17 +670,17 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.GRAVEL).setWeight(9))
                                 .add(LootItem.lootTableItem(Items.BONE_BLOCK).setWeight(5))
                                 .add(LootItem.lootTableItem(Items.GILDED_BLACKSTONE).setWeight(1))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,1)))
                 )
                 .withPool(
                         LootPool.lootPool()
                                 .setRolls(ConstantValue.exactly(1.0F))
                                 .add(EmptyLootItem.emptyItem().setWeight(50))
-                                .add(LootItem.lootTableItem(Items.GLOWSTONE_DUST).setWeight(25).apply(SetItemCountFunction.setCount(UniformGenerator.between(1, 6))))
+                                .add(LootItem.lootTableItem(Items.GLOWSTONE_DUST).setWeight(25).apply(SetItemCountFunction.setCount(UniformGenerator.between(1,6))))
                                 .add(LootItem.lootTableItem(Items.MAGMA_BLOCK).setWeight(15))
                                 .add(LootItem.lootTableItem(Items.GLOWSTONE).setWeight(9))
                                 .add(LootItem.lootTableItem(Items.SHROOMLIGHT).setWeight(1))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,UniformGenerator.between(0,1)))
                 )
                 .withPool(
                         LootPool.lootPool()
@@ -697,11 +689,11 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.OBSIDIAN).setWeight(20))
                                 .add(LootItem.lootTableItem(Items.CRYING_OBSIDIAN).setWeight(4))
                                 .add(LootItem.lootTableItem(Items.ANCIENT_DEBRIS).setWeight(1))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, ConstantValue.exactly(1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries,ConstantValue.exactly(1)))
                 );
     }
 
-    public Builder guardianLootTable() {
+    public LootTable.Builder guardianLootTable(){
         return LootTable.lootTable()
                 .withPool(
                         LootPool.lootPool()
@@ -728,7 +720,7 @@ public class OccultismEntityLoot extends EntityLootSubProvider {
                                 .add(LootItem.lootTableItem(Items.BUBBLE_CORAL))
                                 .add(LootItem.lootTableItem(Items.FIRE_CORAL))
                                 .add(LootItem.lootTableItem(Items.HORN_CORAL))
-                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0, 1)))
+                                .apply(EnchantedCountIncreaseFunction.lootingMultiplier(this.registries, UniformGenerator.between(0,1)))
                 )
                 .withPool(
                         LootPool.lootPool()

--- a/src/main/java/com/klikli_dev/occultism/datagen/tags/OccultismEntityTypeTagProvider.java
+++ b/src/main/java/com/klikli_dev/occultism/datagen/tags/OccultismEntityTypeTagProvider.java
@@ -201,9 +201,6 @@ public class OccultismEntityTypeTagProvider extends EntityTypeTagsProvider {
                 .add(EntityType.TRADER_LLAMA)
                 .add(EntityType.MULE)
                 .add(EntityType.STRIDER);
-
-        this.tag(OccultismTags.Entities.FORCE_KILL_SIMULATION)
-                .add(EntityType.WITHER);
     }
 
     private void addCommonTags() {

--- a/src/main/java/com/klikli_dev/occultism/registry/OccultismTags.java
+++ b/src/main/java/com/klikli_dev/occultism/registry/OccultismTags.java
@@ -280,8 +280,6 @@ public class OccultismTags {
         public static final TagKey<EntityType<?>> RANDOM_ANIMALS_SMALL = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "random_animals_small"));
         public static final TagKey<EntityType<?>> RANDOM_ANIMALS_SPECIAL = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "random_animals_special"));
         public static final TagKey<EntityType<?>> RANDOM_ANIMALS_RIDEABLE = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "random_animals_rideable"));
-
-        public static final TagKey<EntityType<?>> FORCE_KILL_SIMULATION = makeEntityTypeTag(ResourceLocation.fromNamespaceAndPath(Occultism.MODID, "force_kill_simulation"));
     }
 
 


### PR DESCRIPTION
Dimensional Battlefield first check ```data/occultism/loot_table/battlefield/MODID/ENTITY.json```
It will be used if it is not empty, otherwise uses the default entity loot table.

+ LivingDropsEvent is now triggered to generate loot, so modifiers will affect it;
+ Minor correction to the loot parameters;
+ Added custom loot table for wither and ender dragon.

REMOVED tag ```occultism:force_kill_simulation``` and its uses


Note: I backported this from my 26.1 instance because loot modifiers are still strange and had few mods to test integrations with.