### PR TITLE
fix: normalize spirit arm bone names

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/client/render/entity/DjinniRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/entity/DjinniRenderer.java
@@ -60,9 +60,9 @@ public class DjinniRenderer extends OccultismGeoLivingEntityRenderer<DjinniEntit
 
                 String boneName;
                 if (Objects.equals(jobId, OccultismSpiritJobs.MANAGE_MACHINE.getId().toString())) {
-                    boneName = "RARM";
+                    boneName = "arm_right";
                 } else if (Objects.equals(jobId, OccultismSpiritJobs.TRADE_GAMBLER.getId().toString())) {
-                    boneName = "LARM";
+                    boneName = "arm_left";
                 } else {
                     boneName = "bone2";
                 }

--- a/src/main/java/com/klikli_dev/occultism/client/render/entity/FoliotRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/entity/FoliotRenderer.java
@@ -64,10 +64,10 @@ public class FoliotRenderer extends OccultismGeoLivingEntityRenderer<FoliotEntit
                 if (Objects.equals(jobId, OccultismSpiritJobs.FARMER.getId().toString())
                         || Objects.equals(jobId, OccultismSpiritJobs.LUMBERJACK.getId().toString())
                         || Objects.equals(jobId, OccultismSpiritJobs.CLEANER.getId().toString())) {
-                    boneName = "LARM";
+                    boneName = "arm_left";
                     displayContext = ItemDisplayContext.THIRD_PERSON_LEFT_HAND;
                 } else {
-                    boneName = "RARM";
+                    boneName = "arm_right";
                     displayContext = ItemDisplayContext.THIRD_PERSON_RIGHT_HAND;
                 }
                 ItemStackRenderState stackState = RenderUtil.createRenderStateForItem(mainHandStack, this.itemModelResolver, displayContext, animatable);

--- a/src/main/resources/assets/occultism/geckolib/animations/entity/demonic_wife.animation.json
+++ b/src/main/resources/assets/occultism/geckolib/animations/entity/demonic_wife.animation.json
@@ -30,7 +30,7 @@
             }
           }
         },
-        "right_arm": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -55,7 +55,7 @@
             }
           }
         },
-        "left_arm": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -148,7 +148,7 @@
             }
           }
         },
-        "right_arm": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -187,7 +187,7 @@
             }
           }
         },
-        "left_arm": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -298,7 +298,7 @@
             }
           }
         },
-        "right_arm": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -323,7 +323,7 @@
             }
           }
         },
-        "left_arm": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -371,7 +371,7 @@
             ]
           }
         },
-        "right_arm": {
+        "arm_right": {
           "rotation": {
             "vector": [
               -11.72268,
@@ -389,7 +389,7 @@
             ]
           }
         },
-        "left_arm": {
+        "arm_left": {
           "rotation": {
             "vector": [
               -7.48052,
@@ -469,7 +469,7 @@
             ]
           }
         },
-        "right_arm": {
+        "arm_right": {
           "rotation": {
             "vector": [
               -11.72268,
@@ -487,7 +487,7 @@
             ]
           }
         },
-        "left_arm": {
+        "arm_left": {
           "rotation": {
             "vector": [
               -7.48052,

--- a/src/main/resources/assets/occultism/geckolib/animations/entity/djinni_gambler.animation.json
+++ b/src/main/resources/assets/occultism/geckolib/animations/entity/djinni_gambler.animation.json
@@ -67,7 +67,7 @@
             }
           }
         },
-        "RARM": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -335,7 +335,7 @@
             }
           }
         },
-        "LARM": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -440,7 +440,7 @@
             }
           }
         },
-        "RARM": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -465,7 +465,7 @@
             }
           }
         },
-        "LARM": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [

--- a/src/main/resources/assets/occultism/geckolib/animations/entity/djinni_machine_manager.animation.json
+++ b/src/main/resources/assets/occultism/geckolib/animations/entity/djinni_machine_manager.animation.json
@@ -30,7 +30,7 @@
             }
           }
         },
-        "RARM": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -55,7 +55,7 @@
             }
           }
         },
-        "LARM": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -148,7 +148,7 @@
             }
           }
         },
-        "RARM": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -416,7 +416,7 @@
             }
           }
         },
-        "LARM": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [

--- a/src/main/resources/assets/occultism/geckolib/animations/entity/foliot_transporter.animation.json
+++ b/src/main/resources/assets/occultism/geckolib/animations/entity/foliot_transporter.animation.json
@@ -30,7 +30,7 @@
             }
           }
         },
-        "RARM": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -55,7 +55,7 @@
             }
           }
         },
-        "LARM": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -157,7 +157,7 @@
             }
           }
         },
-        "RARM": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -425,7 +425,7 @@
             }
           }
         },
-        "LARM": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -497,7 +497,7 @@
             }
           }
         },
-        "RARM": {
+        "arm_right": {
           "rotation": {
             "0.0": {
               "vector": [
@@ -522,7 +522,7 @@
             }
           }
         },
-        "LARM": {
+        "arm_left": {
           "rotation": {
             "0.0": {
               "vector": [

--- a/src/main/resources/assets/occultism/geckolib/models/entity/demonic_wife.geo.json
+++ b/src/main/resources/assets/occultism/geckolib/models/entity/demonic_wife.geo.json
@@ -24,7 +24,7 @@
           ]
         },
         {
-          "name": "right_arm",
+          "name": "arm_right",
           "parent": "_",
           "pivot": [
             -4,
@@ -34,7 +34,7 @@
         },
         {
           "name": "bone7",
-          "parent": "right_arm",
+          "parent": "arm_right",
           "pivot": [
             -4,
             22.5,
@@ -71,7 +71,7 @@
         },
         {
           "name": "bone8",
-          "parent": "right_arm",
+          "parent": "arm_right",
           "pivot": [
             -4,
             22.5,
@@ -107,7 +107,7 @@
           ]
         },
         {
-          "name": "left_arm",
+          "name": "arm_left",
           "parent": "_",
           "pivot": [
             4,
@@ -117,7 +117,7 @@
         },
         {
           "name": "bone5",
-          "parent": "left_arm",
+          "parent": "arm_left",
           "pivot": [
             4.5,
             24.5,
@@ -154,7 +154,7 @@
         },
         {
           "name": "bone6",
-          "parent": "left_arm",
+          "parent": "arm_left",
           "pivot": [
             0,
             4,

--- a/src/main/resources/assets/occultism/geckolib/models/entity/djinni_gambler.geo.json
+++ b/src/main/resources/assets/occultism/geckolib/models/entity/djinni_gambler.geo.json
@@ -452,7 +452,7 @@
           ]
         },
         {
-          "name": "LARM",
+          "name": "arm_left",
           "parent": "Torso",
           "pivot": [
             -5,
@@ -520,7 +520,7 @@
           ]
         },
         {
-          "name": "RARM",
+          "name": "arm_right",
           "parent": "Torso",
           "pivot": [
             3,

--- a/src/main/resources/assets/occultism/geckolib/models/entity/djinni_machine_manager.geo.json
+++ b/src/main/resources/assets/occultism/geckolib/models/entity/djinni_machine_manager.geo.json
@@ -510,7 +510,7 @@
           ]
         },
         {
-          "name": "LARM",
+          "name": "arm_left",
           "parent": "Torso",
           "pivot": [
             -5,
@@ -552,7 +552,7 @@
           ]
         },
         {
-          "name": "RARM",
+          "name": "arm_right",
           "parent": "Torso",
           "pivot": [
             3,

--- a/src/main/resources/assets/occultism/geckolib/models/entity/foliot_transporter.geo.json
+++ b/src/main/resources/assets/occultism/geckolib/models/entity/foliot_transporter.geo.json
@@ -362,7 +362,7 @@
           ]
         },
         {
-          "name": "LARM",
+          "name": "arm_left",
           "parent": "Torso",
           "pivot": [
             -5,
@@ -405,7 +405,7 @@
         },
         {
           "name": "bone3",
-          "parent": "LARM",
+          "parent": "arm_left",
           "pivot": [
             -3.56,
             4.8,
@@ -622,7 +622,7 @@
           ]
         },
         {
-          "name": "RARM",
+          "name": "arm_right",
           "parent": "Torso",
           "pivot": [
             3,


### PR DESCRIPTION
## Summary
- normalize spirit renderer arm bone references to arm_left and arm_right
- rename mismatched geo model arm bones to arm_left and arm_right
- rename matching animation bone references to keep spirit assets consistent