### PR TITLE
fix: infinite loop miner with one durability

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalMineshaftBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/DimensionalMineshaftBlockEntity.java
@@ -356,13 +356,11 @@ public class DimensionalMineshaftBlockEntity extends NetworkedBlockEntity implem
             ItemTransferUtil.insertItemStacked(currentHandler, drop, false);
         }
 
-        boolean shouldSaveMiner = this.saveMiner && input.isDamageableItem() && input.nextDamageWillBreak();
-        if (shouldSaveMiner) {
+        input.hurtAndBreak(1, (ServerLevel) this.level, (LivingEntity) null, (item) -> {});
+        //Check if the next operation will break the miner
+        if (this.saveMiner && input.nextDamageWillBreak()) {
             ItemTransferUtil.insertItemStacked(currentHandler, input.copy(), false);
             input.shrink(1);
-        } else {
-            input.hurtAndBreak(1, (ServerLevel) this.level, (LivingEntity) null, (item) -> {
-            });
         }
         this.inputHandler.set(0, ItemResource.of(input), input.getCount());
     }


### PR DESCRIPTION
The current logic allows the miner to operate with 1 durability, going to the output while retaining 1 durability remaining and this allows for the creation of an infinite loop.

Gemini troll review in #1591

note: `input.isDamageableItem()` it's already checked in `input.nextDamageWillBreak()`