### PR TITLE
fix: prevent crash when inserting air into sacrificial bowl

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/block/SacrificialBowlBlock.java
+++ b/src/main/java/com/klikli_dev/occultism/common/block/SacrificialBowlBlock.java
@@ -86,7 +86,7 @@ public class SacrificialBowlBlock extends DirectionalBlock implements EntityBloc
             var handler = bowl.itemStackHandler;
             if (!pPlayer.isShiftKeyDown()) {
                 ItemStack itemStack = handler.getResource(0).toStack();
-                if (itemStack.isEmpty()) {
+                if (itemStack.isEmpty() && !heldItem.isEmpty()) {
                     //if there is nothing in the bowl, put the hand held item in
                     try (var tx = Transaction.openRoot()) {
                         int inserted = handler.insert(0, ItemResource.of(heldItem), 1, tx);


### PR DESCRIPTION
Adds a !heldItem.isEmpty() check to SacrificialBowlBlock.useItemOn() before attempting to insert into the handler.

When a player interacts with an empty hand (e.g. via a Clicker from Just Dire Things), ItemResource.of(heldItem) creates an ItemResource for minecraft:air, causing an IllegalArgumentException in NeoForge's TransferPreconditions.checkNonEmpty.