### PR TITLE
fix: prevent ClientLevel memory leak on dimension change/disconnect

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
+++ b/src/main/java/com/klikli_dev/occultism/client/render/blockentity/GoldenSacrificialBowlRenderer.java
@@ -62,6 +62,7 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
 
     private final ItemModelResolver itemModelResolver;
     private final Map<EntityType<?>, LivingEntity> sacrificePreviewEntities = new HashMap<>();
+    private @Nullable Level cachedLevel = null;
 
     public GoldenSacrificialBowlRenderer(Context context) {
         this.itemModelResolver = context.itemModelResolver();
@@ -181,6 +182,11 @@ public class GoldenSacrificialBowlRenderer implements BlockEntityRenderer<Sacrif
     private LivingEntity getSacrificePreviewEntity(@Nullable EntityType<?> entityType, @Nullable Level level) {
         if (entityType == null || level == null) {
             return null;
+        }
+
+        if (this.cachedLevel != level) {
+            this.sacrificePreviewEntities.clear();
+            this.cachedLevel = level;
         }
 
         LivingEntity cached = this.sacrificePreviewEntities.get(entityType);

--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
@@ -691,11 +691,15 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
     @Override
     public void preRemoveSideEffects(BlockPos pos, BlockState state) {
         this.stopRitual(false);
+        // Defensive: ensure listeners are always unregistered when the block entity is removed,
+        // even if stopRitual() could not run (e.g. level is null during unload).
+        NeoForge.EVENT_BUS.unregister(this.rightClickItemListener);
+        NeoForge.EVENT_BUS.unregister(this.livingDeathEventListener);
         super.preRemoveSideEffects(pos, state);
     }
 
     public void stopRitual(boolean finished, boolean showInterruptedMessage) {
-        if (!this.level.isClientSide()) {
+        if (this.level != null && !this.level.isClientSide()) {
             var recipe = this.getCurrentRitualRecipe();
             if (recipe != null) {
                 if (finished) {


### PR DESCRIPTION
## Summary

Fixes #1670 — memory leak caused by stale ClientLevel references surviving across dimension changes and disconnects.

## Changes

### GoldenSacrificialBowlRenderer (primary fix)
- Added cachedLevel field to track the current level
- Clear the sacrificePreviewEntities cache when the level changes, preventing old ClientLevel references from persisting via cached LivingEntity objects

### GoldenSacrificialBowlBlockEntity (defensive fix)
- Added defensive NeoForge.EVENT_BUS.unregister() calls in preRemoveSideEffects() to ensure event listeners are always cleaned up when the block entity is removed, even if stopRitual() could not run (e.g. level is null during unload)
- Added null check for 	his.level in stopRitual() to prevent NPE when the level is null during removal

## Root Cause

GoldenSacrificialBowlRenderer is a singleton BlockEntityRenderer cached by BlockEntityRenderDispatcher. Its sacrificePreviewEntities map stores LivingEntity objects created via entityType.create(level, ...) where level is a ClientLevel. These entities hold references to the ClientLevel through their Entity.level field. When the player changes dimensions or disconnects, a new ClientLevel is created, but the renderer (and its cached entities referencing the old level) persists. Without clearing the cache on level change, old ClientLevel instances are retained and cannot be garbage collected.