### PR TITLE
fix: prevent ClientLevel memory leak on dimension change/disconnect

### DIFF
--- a/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
+++ b/src/main/java/com/klikli_dev/occultism/common/blockentity/GoldenSacrificialBowlBlockEntity.java
@@ -313,8 +313,10 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
                 var recipe = this.level.getRecipeManager().byKey(this.currentRitualRecipeId);
                 recipe.map(r -> (RecipeHolder<RitualRecipe>) r).ifPresent(r -> this.currentRitualRecipe = r);
 
-                NeoForge.EVENT_BUS.addListener(this.rightClickItemListener);
-                NeoForge.EVENT_BUS.addListener(this.livingDeathEventListener);
+                if (this.level instanceof ServerLevel) {
+                    NeoForge.EVENT_BUS.addListener(this.rightClickItemListener);
+                    NeoForge.EVENT_BUS.addListener(this.livingDeathEventListener);
+                }
 
                 this.currentRitualRecipeId = null;
             }
@@ -654,8 +656,15 @@ public class GoldenSacrificialBowlBlockEntity extends SacrificialBowlBlockEntity
         this.stopRitual(finished, true);
     }
 
+    @Override
+    public void onChunkUnloaded() {
+        super.onChunkUnloaded();
+        NeoForge.EVENT_BUS.unregister(this.rightClickItemListener);
+        NeoForge.EVENT_BUS.unregister(this.livingDeathEventListener);
+    }
+
     public void stopRitual(boolean finished, boolean showInterruptedMessage) {
-        if (!this.level.isClientSide) {
+        if (this.level != null && !this.level.isClientSide) {
             var recipe = this.getCurrentRitualRecipe();
             if (recipe != null) {
                 IItemHandler handler = this.itemStackHandler;


### PR DESCRIPTION
## Summary

Fixes #1670 — memory leak caused by stale ClientLevel references surviving across dimension changes and disconnects.

## Changes

### GoldenSacrificialBowlBlockEntity (all fixes)

1. **getCurrentRitualRecipe()** (root cause fix): Added 	his.level instanceof ServerLevel guard around the NeoForge.EVENT_BUS.addListener() calls. Previously, these were called unconditionally when 	his.level != null, meaning on the client side listeners were registered but could never be unregistered (since stopRitual() is guarded by !this.level.isClientSide). This caused the ClientLevel to be retained by the event bus indefinitely.

2. **onChunkUnloaded()** (defensive fix): Added override to defensively unregister event listeners when the block entity's chunk is unloaded, preventing leaks if stopRitual() was not called before chunk unload.

3. **stopRitual()** (null safety): Added null check for 	his.level to prevent NPE when the level is null during unload.

## Root Cause

In the 1.21.1 codebase, GoldenSacrificialBowlBlockEntity.getCurrentRitualRecipe() registered ightClickItemListener and livingDeathEventListener on NeoForge.EVENT_BUS without checking whether the level was server-side. On the client, these lambdas captured 	his (the block entity), which holds a 	his.level reference to the ClientLevel. Since stopRitual() only unregisters inside a !this.level.isClientSide guard, the client-side registrations were never cleaned up, preventing the ClientLevel from being garbage collected on dimension change or disconnect.

The 26.1 branch had the same latent risk (mitigated by the instanceof ServerLevel guard already present in getCurrentRitualRecipe()), and also had an additional leak vector in GoldenSacrificialBowlRenderer.sacrificePreviewEntities (fixed separately in PR #1674).